### PR TITLE
Remove pluginFiles recursive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ programs.lazyvim = {
 programs.lazyvim = {
   enable = true;
 
+  pluginFiles = ./lua/plugins;
+
   config = {
     options = ''
       vim.opt.relativenumber = false
@@ -92,6 +94,10 @@ programs.lazyvim = {
   };
 };
 ```
+
+The optional `pluginFiles` directory lets you keep regular Lua plugin files (e.g. `./lua/plugins/*.lua`).
+Each `.lua` file is linked into `~/.config/nvim/lua/plugins/`, and if a filename conflicts with an inline
+`plugins` entry, the real file takes precedence with a warning at evaluation time.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary
- drop the unused `pluginFilesRecursive` option and simplify plugin directory scanning to only read the immediate directory

## Testing
- not run (nix command not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68efaa5f5878832d8d55eed1997da7fb