### PR TITLE
fix(treesitter): improve Nix compatibility with version-agnostic mocking

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -443,13 +443,83 @@ let
         { "mason-org/mason.nvim", enabled = false },
         { "mason-org/mason-lspconfig.nvim", enabled = false },
         { "jay-babu/mason-nvim-dap.nvim", enabled = false },
-        -- Disable treesitter auto-install and build warnings (managed by Nix)
+        -- Configure treesitter to work with Nix-managed parsers
         {
           "nvim-treesitter/nvim-treesitter",
-          build = false,  -- Disable build function that shows update warnings
+          -- Parser compilation is skipped when using Nix
+          build = false,
           opts = function(_, opts)
+            opts.auto_install = false
             opts.ensure_installed = {}
+            return opts
           end,
+          config = function(_, opts)
+
+            local TS = require("nvim-treesitter")
+            local LazyVimUtil = require("lazyvim.util")
+
+            -- Mock TS.get_installed to bypass the installation checks
+            -- See nvim-treesitter/lua/nvim-treesitter/config.lua#L42-L58
+            local _ts_install = TS.get_installed
+            TS.get_installed = function()
+              return {}
+            end
+
+            -- Mock LazyVimUtil.treesitter.get_installed() to populate M._installed
+            -- from the buildtime parser list. This ensures M._installed is
+            -- populated correctly for autocmd functionality
+            -- See LazyVim/lua/lazyvim/util/treesitter.lua#L7-L17
+            local _lazyvim_install = LazyVimUtil.treesitter.get_installed
+
+            -- Nix-managed parser list (extracted from treesitterParsers option)
+            local nix_parsers = { ${treesitterLangList} }
+
+            LazyVimUtil.treesitter.get_installed = function(update)
+              if update then
+                LazyVimUtil.treesitter._installed = {}
+                LazyVimUtil.treesitter._queries = {}
+                for _, lang in ipairs(nix_parsers) do
+                  LazyVimUtil.treesitter._installed[lang] = true
+                end
+              end
+              return LazyVimUtil.treesitter._installed or {}
+            end
+
+            -- Find and call LazyVim's default config
+            -- This will:
+            -- 1. Pass the version check (TS.get_installed returns empty)
+            -- 2. Setup treesitter with our opts
+            -- 3. Skip parser installation (ensure_installed is empty)
+            -- 4. Populate M._installed with Nix parsers (our LazyVim mock)
+            -- 5. Create autocmds for highlighting, indents, folds
+            local treesitter_plugins = require("lazyvim.plugins.treesitter")
+            local config_fn = nil
+
+            -- Search for first nvim-treesitter plugin spec by identifier
+            for _, spec in ipairs(treesitter_plugins) do
+              if spec[1] == "nvim-treesitter/nvim-treesitter" and
+                 type(spec.config) == "function" then
+                config_fn = spec.config
+                break
+              end
+            end
+
+            if not config_fn then
+              error("Failed to find nvim-treesitter config in lazyvim.plugins.treesitter")
+            else
+              config_fn(_, opts)
+            end
+
+            -- Restore pre-mock references
+            LazyVimUtil.treesitter.get_installed = _lazyvim_install
+            if _ts_install then
+              TS.get_installed = _ts_install
+            else
+              TS.get_installed = nil
+            end
+          end,
+          dev = true,
+          pin = true,
         },
         -- Mark available plugins as dev = true
         ${concatStringsSep "\n        " availableDevSpecs}
@@ -473,7 +543,25 @@ let
     })
     
   '';
-  
+
+  # Extract language names from treesitter parser packages for Lua config
+  treesitterLangNames = let
+    extractLang = pkg:
+      let
+        pname = pkg.pname or "";
+        # Remove "tree-sitter-" prefix to get language name
+        lang = lib.removePrefix "tree-sitter-" pname;
+      in
+        # Only include if prefix was present (validates it's a treesitter parser)
+        if lang != pname then lang else null;
+
+    langs = map extractLang cfg.treesitterParsers;
+  in
+    lib.filter (l: l != null) langs;
+
+  # Generate Lua array string for parser list
+  treesitterLangList = lib.concatStringsSep ", " (map (l: ''"${l}"'') treesitterLangNames);
+
   # Treesitter configuration - using packages directly
   treesitterGrammars = let
     parsers = pkgs.symlinkJoin {


### PR DESCRIPTION
**Problem**

LazyVim's treesitter configuration performs version checks via `TS.get_installed()` that fail when parsers are managed by Nix instead of lazy.nvim's package manager. Setting `ensure_installed = {}` prevents LazyVim from setting up treesitter autocmds for highlighting, indents, and folds, as well as language-specific treesitter features in extras, because no parsers are registered with LazyVim.

**Solution**

This PR maintains full LazyVim treesitter functionality while working with any nvim-treesitter version from nixpkgs.

**Implementation**

- **Build-time parser extraction**: Extract parser names from `treesitterParsers` option at build-time ([module.nix:548-563](./module.nix#L548-563))

- **Compatibility shims** to mock the configuration required by LazyVim:
  - `TS.get_installed()`: Bypasses nvim-treesitter's installation checks (see [nvim-treesitter/lua/nvim-treesitter/config.lua#L42-L58](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/lua/nvim-treesitter/config.lua#L42-L58))
  - `LazyVimUtil.treesitter.get_installed()`: Inlines the list of Nix-managed parsers at build-time as a string table (see [LazyVim/lua/lazyvim/util/treesitter.lua#L7-L17](https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/util/treesitter.lua#L7-L17))

- **Dynamic configuration discovery**: Programmatically finds and calls LazyVim's treesitter plugin spec's `config` function to support future upstream configuration changes
