### PR TITLE
feat(lib): add Lua module loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,75 @@ programs.lazyvim = {
 };
 ```
 
+### Configuration via Lua Modules
+
+For larger configurations, you can organize your Lua code in separate files using the included Lua module loader:
+
+```nix
+# modules/editors/neovim.nix
+{
+  pkgs,
+  lib,
+  lazyvim,
+  ...
+}:
+
+let
+  # Path to your Lua configuration directory
+  luaPath = ../../config/nvim/lua;
+  luaLoader = (pkgs.callPackage "${lazyvim}/lib/lua.nix" {
+    inherit pkgs lib;
+  }).moduleLoader luaPath;
+  inherit (luaLoader) require importSpecs;
+in
+{
+  imports = [ lazyvim.homeManagerModules.default ];
+
+  programs.lazyvim = {
+    enable = true;
+
+    # Load config from external Lua files
+    config = importSpecs "config" [
+      "options"    # Loads config/nvim/lua/config/options.lua
+      "keymaps"    # Loads config/nvim/lua/config/keymaps.lua
+      "autocmds"   # Loads config/nvim/lua/config/autocmds.lua
+    ];
+
+    # Load plugin overrides from external Lua files
+    plugins =
+      importSpecs "plugins" [
+        "colorscheme"      # Loads config/nvim/lua/plugins/colorscheme.lua
+        "nvim-treesitter"  # Loads config/nvim/lua/plugins/nvim-treesitter.lua
+        "lsp"              # Loads config/nvim/lua/plugins/lsp.lua
+      ]
+      // {
+        # Can still mix with inline configs
+        custom-plugin = ''
+          return {
+            "author/plugin.nvim",
+            opts = {},
+          }
+        '';
+      };
+  };
+}
+```
+
+**File Structure Example:**
+```
+config/nvim/lua/
+├── config/
+│   ├── options.lua
+│   ├── keymaps.lua
+│   └── autocmds.lua
+└── plugins/
+    ├── colorscheme.lua
+    ├── nvim-treesitter.lua
+    └── lsp.lua
+```
+
+The Lua module loader uses `package.searchpath` at build time to resolve module paths with the same logic as runtime Lua, ensuring consistency between Nix builds and Neovim's require system. Files are read during home-manager activation, so syntax errors are caught at build time rather than when starting Neovim.
+
 ## Key Features
 
 - 🚀 **Always up-to-date** - Automatically tracks LazyVim releases with latest plugin versions

--- a/lib/lua.nix
+++ b/lib/lua.nix
@@ -1,0 +1,78 @@
+{ pkgs, lib }:
+
+{
+  # Lua module loader for build-time resolution of Lua files
+  #
+  # This provides utilities to load Lua modules from a directory at build time,
+  # using the same search path logic as runtime Lua. This is useful for:
+  # - Loading user plugin configurations from ~/.config/nvim/lua/plugins/
+  # - Loading custom config files from ~/.config/nvim/lua/config/
+  # - Ensuring consistent module resolution between Nix build and runtime
+  moduleLoader =
+    luaPath:
+    let
+      searchPath = "${luaPath}/?.lua;${luaPath}/?/init.lua";
+    in
+    {
+      # Resolve Lua module path using package.searchpath at build time
+      # This guarantees we use the exact same resolution logic as runtime
+      #
+      # Args:
+      #   module: Lua module name (e.g., "config.options")
+      #
+      # Returns:
+      #   Absolute path to the resolved Lua module file
+      search =
+        module:
+        let
+          modulePath = builtins.readFile (
+            pkgs.runCommand "package-searchpath-${module}" { } ''
+              ${pkgs.luajit}/bin/luajit - > $out <<'EOF'
+              local path = package.searchpath("${module}", "${searchPath}")
+              if path then
+                io.write(path)
+              else
+                error("Module '${module}' not found in search path: ${searchPath}")
+              end
+              EOF
+            ''
+          );
+        in
+        lib.strings.removeSuffix "\n" modulePath;
+
+      # Load Lua module content by resolving path and reading file
+      #
+      # Args:
+      #   module: Lua module name (e.g., "config.options")
+      #
+      # Returns:
+      #   String content of the Lua module file
+      require =
+        module:
+        let
+          luaLib = (pkgs.callPackage ./lua.nix { inherit pkgs lib; }).moduleLoader luaPath;
+        in
+        builtins.readFile (luaLib.search module);
+
+      # Load multiple modules with a prefix
+      #
+      # Args:
+      #   prefix: Module prefix (e.g., "plugins")
+      #   modules: List of module names (e.g., ["colorscheme" "mason"])
+      #
+      # Returns:
+      #   Attribute set of module names to their contents
+      #   { colorscheme = <contents>; mason = <contents>; }
+      importSpecs =
+        prefix: modules:
+        let
+          luaLib = (pkgs.callPackage ./lua.nix { inherit pkgs lib; }).moduleLoader luaPath;
+        in
+        lib.listToAttrs (
+          map (name: {
+            inherit name;
+            value = luaLib.require "${prefix}.${name}";
+          }) modules
+        );
+    };
+}


### PR DESCRIPTION
This PR adds a build-time Lua module loader that resolves external `.lua` files using the same search path logic as runtime Lua through a shell invocation of `luajit`, allowing users to organize their configuration in standard Neovim directory structures and leverage LSP during configuration development while getting build-time validation while maintaining Nix's build-time validation.

## Implementation

- **Lua module loader** (`lib/lua.nix`): Provides three core functions:
  - `search(module)`: Resolves module path using `package.searchpath` at build time
  - `require(module)`: Loads module content as string
  - `importSpecs(prefix, modules)`: Bulk-loads multiple modules into an attrset
- Uses `luajit` to execute `package.searchpath` during Nix evaluation, guaranteeing identical module resolution between build and runtime
- Files are read during home-manager activation, catching Lua syntax errors before Neovim starts

## Usage

```nix
let
  luaPath = ../../config/nvim/lua; # Directly sets package.path (LUA_PATH)
  luaLoader = (pkgs.callPackage "${lazyvim}/lib/lua.nix" {
    inherit pkgs lib;
  }).moduleLoader luaPath;
  inherit (luaLoader) require importSpecs;
in
{
  programs.lazyvim = {
    enable = true;

    config = importSpecs "config" [
      "options"    # Loads config/nvim/lua/config/options.lua
      "keymaps"
      "autocmds"
    ];

    plugins = importSpecs "plugins" [
      "colorscheme"
      "lsp"
    ];
  };
}
```