### PR TITLE
Allow custom config directories

### DIFF
--- a/nix/lib/config-generation.nix
+++ b/nix/lib/config-generation.nix
@@ -7,13 +7,13 @@
     map (extra: ''{ import = "${extra.import}" },'') enabledExtras;
 
   # Generate extras config override files for extras with custom config
-  extrasConfigFiles = enabledExtras:
+  extrasConfigFiles = enabledExtras: appName:
     let
       extrasWithConfig = lib.filter (extra: extra.hasConfig) enabledExtras;
     in
       lib.listToAttrs (map (extra:
         lib.nameValuePair
-          "nvim/lua/plugins/extras-${extra.category}-${extra.name}.lua"
+          "${appName}/lua/plugins/extras-${extra.category}-${extra.name}.lua"
           {
             text = ''
               -- Extra configuration override for ${extra.category}/${extra.name} (configured via Nix)

--- a/nix/lib/file-scanning.nix
+++ b/nix/lib/file-scanning.nix
@@ -57,7 +57,7 @@
       userPluginsList;
 
   # Helper function to scan config files from a directory
-  scanConfigFiles = configPath:
+  scanConfigFiles = configPath: appName:
     if configPath == null then
       { configFiles = {}; pluginFiles = {}; }
     else if !builtins.pathExists configPath then
@@ -88,16 +88,16 @@
             targetPath =
               if lib.hasPrefix "lua/" relPath then
                 # Already has lua/ prefix, use as-is
-                "nvim/${relPath}"
+                "${appName}/${relPath}"
               else if lib.hasPrefix "config/" relPath then
                 # config/ at root, add lua/ prefix
-                "nvim/lua/${relPath}"
+                "${appName}/lua/${relPath}"
               else if lib.hasPrefix "plugins/" relPath then
                 # plugins/ at root, add lua/ prefix
-                "nvim/lua/${relPath}"
+                "${appName}/lua/${relPath}"
               else
                 # Other structure - put under lua/
-                "nvim/lua/${relPath}";
+                "${appName}/lua/${relPath}";
 
             # Determine file category for conflict detection
             category =

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -6,6 +6,16 @@ with lib;
 {
   enable = mkEnableOption "LazyVim - A Neovim configuration framework";
 
+  appName = mkOption {
+    type = types.str;
+    default = "nvim";
+    example = "lazyvim";
+    description = ''
+      The app name for Neovim's NVIM_APPNAME environment variable.
+      This determines the config directory under ~/.config/ (e.g., "lazyvim" → ~/.config/lazyvim/).
+    '';
+  };
+
   pluginSource = mkOption {
     type = types.enum [ "latest" "nixpkgs" ];
     default = "latest";


### PR DESCRIPTION
changes the hardcoded 

"~/.config/nvim"

 to be configurable with the appName option to allow the generation of config files in alternate directories like 

"~/.config/lazyvim"
 
  for those who keep multiple copies of neovim on their nix system


Not sure if appName is the best for the options name, but figured it would follow the convention of setting NVIM_APPNAME