### PR TITLE
Add support for LazyVim v15.15.0 nested configuration

### DIFF
--- a/data/dependencies.json
+++ b/data/dependencies.json
@@ -299,7 +299,8 @@
     ],
     "lang.json": [
       {
-        "name": "jsonls"
+        "name": "jsonls",
+        "nixpkg": "vscode-langservers-extracted"
       }
     ],
     "lang.kotlin": [
@@ -493,6 +494,7 @@
     "lang.typescript.biome": [
       {
         "name": "biome",
+        "nixpkg": "biome",
         "runtime_dependencies": [
           {
             "name": "nodejs",
@@ -512,6 +514,7 @@
     "lang.typescript.oxc": [
       {
         "name": "oxlint",
+        "nixpkg": "oxlint",
         "runtime_dependencies": [
           {
             "name": "nodejs",
@@ -527,6 +530,7 @@
       },
       {
         "name": "oxfmt",
+        "nixpkg": "oxfmt",
         "runtime_dependencies": [
           {
             "name": "nodejs",
@@ -541,6 +545,7 @@
     "lang.typescript.tsgo": [
       {
         "name": "tsgo",
+        "nixpkg": "typescript-go",
         "runtime_dependencies": [
           {
             "name": "nodejs",
@@ -555,6 +560,7 @@
     "lang.typescript.vtsls": [
       {
         "name": "vtsls",
+        "nixpkg": "vtsls",
         "runtime_dependencies": [
           {
             "name": "nodejs",
@@ -596,7 +602,7 @@
       }
     ]
   },
-  "generated": "2026-04-02 17:28:42",
-  "lazyvim_path": "/tmp/nix-shell.hvlVn7/tmp.R8IWoDhTGv/LazyVim",
+  "generated": "2026-04-05 18:35:49",
+  "lazyvim_path": "/tmp/nix-shell.9qYsb6/tmp.xqSWs8Zjj4/LazyVim",
   "mason_path": "/home/runner/work/lazyvim-nix/lazyvim-nix/tmp/update-cache/mason-registry"
 }

--- a/data/extras.json
+++ b/data/extras.json
@@ -3,46 +3,55 @@
     "avante": {
       "category": "ai",
       "import": "lazyvim.plugins.extras.ai.avante",
+      "is_nested": false,
       "name": "avante"
     },
     "claudecode": {
       "category": "ai",
       "import": "lazyvim.plugins.extras.ai.claudecode",
+      "is_nested": false,
       "name": "claudecode"
     },
     "codeium": {
       "category": "ai",
       "import": "lazyvim.plugins.extras.ai.codeium",
+      "is_nested": false,
       "name": "codeium"
     },
     "copilot": {
       "category": "ai",
       "import": "lazyvim.plugins.extras.ai.copilot",
+      "is_nested": false,
       "name": "copilot"
     },
     "copilot_chat": {
       "category": "ai",
       "import": "lazyvim.plugins.extras.ai.copilot-chat",
+      "is_nested": false,
       "name": "copilot-chat"
     },
     "copilot_native": {
       "category": "ai",
       "import": "lazyvim.plugins.extras.ai.copilot-native",
+      "is_nested": false,
       "name": "copilot-native"
     },
     "sidekick": {
       "category": "ai",
       "import": "lazyvim.plugins.extras.ai.sidekick",
+      "is_nested": false,
       "name": "sidekick"
     },
     "supermaven": {
       "category": "ai",
       "import": "lazyvim.plugins.extras.ai.supermaven",
+      "is_nested": false,
       "name": "supermaven"
     },
     "tabnine": {
       "category": "ai",
       "import": "lazyvim.plugins.extras.ai.tabnine",
+      "is_nested": false,
       "name": "tabnine"
     }
   },
@@ -50,41 +59,49 @@
     "blink": {
       "category": "coding",
       "import": "lazyvim.plugins.extras.coding.blink",
+      "is_nested": false,
       "name": "blink"
     },
     "luasnip": {
       "category": "coding",
       "import": "lazyvim.plugins.extras.coding.luasnip",
+      "is_nested": false,
       "name": "luasnip"
     },
     "mini_comment": {
       "category": "coding",
       "import": "lazyvim.plugins.extras.coding.mini-comment",
+      "is_nested": false,
       "name": "mini-comment"
     },
     "mini_snippets": {
       "category": "coding",
       "import": "lazyvim.plugins.extras.coding.mini-snippets",
+      "is_nested": false,
       "name": "mini-snippets"
     },
     "mini_surround": {
       "category": "coding",
       "import": "lazyvim.plugins.extras.coding.mini-surround",
+      "is_nested": false,
       "name": "mini-surround"
     },
     "neogen": {
       "category": "coding",
       "import": "lazyvim.plugins.extras.coding.neogen",
+      "is_nested": false,
       "name": "neogen"
     },
     "nvim_cmp": {
       "category": "coding",
       "import": "lazyvim.plugins.extras.coding.nvim-cmp",
+      "is_nested": false,
       "name": "nvim-cmp"
     },
     "yanky": {
       "category": "coding",
       "import": "lazyvim.plugins.extras.coding.yanky",
+      "is_nested": false,
       "name": "yanky"
     }
   },
@@ -92,11 +109,13 @@
     "core": {
       "category": "dap",
       "import": "lazyvim.plugins.extras.dap.core",
+      "is_nested": false,
       "name": "core"
     },
     "nlua": {
       "category": "dap",
       "import": "lazyvim.plugins.extras.dap.nlua",
+      "is_nested": false,
       "name": "nlua"
     }
   },
@@ -104,91 +123,109 @@
     "aerial": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.aerial",
+      "is_nested": false,
       "name": "aerial"
     },
     "dial": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.dial",
+      "is_nested": false,
       "name": "dial"
     },
     "fzf": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.fzf",
+      "is_nested": false,
       "name": "fzf"
     },
     "harpoon2": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.harpoon2",
+      "is_nested": false,
       "name": "harpoon2"
     },
     "illuminate": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.illuminate",
+      "is_nested": false,
       "name": "illuminate"
     },
     "inc_rename": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.inc-rename",
+      "is_nested": false,
       "name": "inc-rename"
     },
     "leap": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.leap",
+      "is_nested": false,
       "name": "leap"
     },
     "mini_diff": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.mini-diff",
+      "is_nested": false,
       "name": "mini-diff"
     },
     "mini_files": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.mini-files",
+      "is_nested": false,
       "name": "mini-files"
     },
     "mini_move": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.mini-move",
+      "is_nested": false,
       "name": "mini-move"
     },
     "navic": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.navic",
+      "is_nested": false,
       "name": "navic"
     },
     "neo_tree": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.neo-tree",
+      "is_nested": false,
       "name": "neo-tree"
     },
     "outline": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.outline",
+      "is_nested": false,
       "name": "outline"
     },
     "overseer": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.overseer",
+      "is_nested": false,
       "name": "overseer"
     },
     "refactoring": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.refactoring",
+      "is_nested": false,
       "name": "refactoring"
     },
     "snacks_explorer": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.snacks_explorer",
+      "is_nested": false,
       "name": "snacks_explorer"
     },
     "snacks_picker": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.snacks_picker",
+      "is_nested": false,
       "name": "snacks_picker"
     },
     "telescope": {
       "category": "editor",
       "import": "lazyvim.plugins.extras.editor.telescope",
+      "is_nested": false,
       "name": "telescope"
     }
   },
@@ -196,11 +233,13 @@
     "black": {
       "category": "formatting",
       "import": "lazyvim.plugins.extras.formatting.black",
+      "is_nested": false,
       "name": "black"
     },
     "prettier": {
       "category": "formatting",
       "import": "lazyvim.plugins.extras.formatting.prettier",
+      "is_nested": false,
       "name": "prettier"
     }
   },
@@ -208,246 +247,319 @@
     "angular": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.angular",
+      "is_nested": false,
       "name": "angular"
     },
     "ansible": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.ansible",
+      "is_nested": false,
       "name": "ansible"
     },
     "astro": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.astro",
+      "is_nested": false,
       "name": "astro"
     },
     "clangd": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.clangd",
+      "is_nested": false,
       "name": "clangd"
     },
     "clojure": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.clojure",
+      "is_nested": false,
       "name": "clojure"
     },
     "cmake": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.cmake",
+      "is_nested": false,
       "name": "cmake"
     },
     "dart": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.dart",
+      "is_nested": false,
       "name": "dart"
     },
     "docker": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.docker",
+      "is_nested": false,
       "name": "docker"
     },
     "dotnet": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.dotnet",
+      "is_nested": false,
       "name": "dotnet"
     },
     "elixir": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.elixir",
+      "is_nested": false,
       "name": "elixir"
     },
     "elm": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.elm",
+      "is_nested": false,
       "name": "elm"
     },
     "ember": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.ember",
+      "is_nested": false,
       "name": "ember"
     },
     "erlang": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.erlang",
+      "is_nested": false,
       "name": "erlang"
     },
     "git": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.git",
+      "is_nested": false,
       "name": "git"
     },
     "gleam": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.gleam",
+      "is_nested": false,
       "name": "gleam"
     },
     "go": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.go",
+      "is_nested": false,
       "name": "go"
     },
     "haskell": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.haskell",
+      "is_nested": false,
       "name": "haskell"
     },
     "helm": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.helm",
+      "is_nested": false,
       "name": "helm"
     },
     "java": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.java",
+      "is_nested": false,
       "name": "java"
     },
     "json": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.json",
+      "is_nested": false,
       "name": "json"
     },
     "julia": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.julia",
+      "is_nested": false,
       "name": "julia"
     },
     "kotlin": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.kotlin",
+      "is_nested": false,
       "name": "kotlin"
     },
     "lean": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.lean",
+      "is_nested": false,
       "name": "lean"
     },
     "markdown": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.markdown",
+      "is_nested": false,
       "name": "markdown"
     },
     "nix": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.nix",
+      "is_nested": false,
       "name": "nix"
     },
     "nushell": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.nushell",
+      "is_nested": false,
       "name": "nushell"
     },
     "ocaml": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.ocaml",
+      "is_nested": false,
       "name": "ocaml"
     },
     "php": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.php",
+      "is_nested": false,
       "name": "php"
     },
     "prisma": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.prisma",
+      "is_nested": false,
       "name": "prisma"
     },
     "python": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.python",
+      "is_nested": false,
       "name": "python"
     },
     "r": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.r",
+      "is_nested": false,
       "name": "r"
     },
     "rego": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.rego",
+      "is_nested": false,
       "name": "rego"
     },
     "ruby": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.ruby",
+      "is_nested": false,
       "name": "ruby"
     },
     "rust": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.rust",
+      "is_nested": false,
       "name": "rust"
     },
     "scala": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.scala",
+      "is_nested": false,
       "name": "scala"
     },
     "solidity": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.solidity",
+      "is_nested": false,
       "name": "solidity"
     },
     "sql": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.sql",
+      "is_nested": false,
       "name": "sql"
     },
     "svelte": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.svelte",
+      "is_nested": false,
       "name": "svelte"
     },
     "tailwind": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.tailwind",
+      "is_nested": false,
       "name": "tailwind"
     },
     "terraform": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.terraform",
+      "is_nested": false,
       "name": "terraform"
     },
     "tex": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.tex",
+      "is_nested": false,
       "name": "tex"
     },
     "thrift": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.thrift",
+      "is_nested": false,
       "name": "thrift"
     },
     "toml": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.toml",
+      "is_nested": false,
       "name": "toml"
-    },
-    "typescript": {
-      "category": "lang",
-      "import": "lazyvim.plugins.extras.lang.typescript",
-      "name": "typescript"
     },
     "twig": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.twig",
+      "is_nested": false,
       "name": "twig"
+    },
+    "typescript": {
+      "category": "lang",
+      "import": "lazyvim.plugins.extras.lang.typescript",
+      "is_nested": false,
+      "name": "typescript"
+    },
+    "typescript.biome": {
+      "category": "lang",
+      "import": "lazyvim.plugins.extras.lang.typescript.biome",
+      "is_nested": true,
+      "name": "typescript.biome"
+    },
+    "typescript.oxc": {
+      "category": "lang",
+      "import": "lazyvim.plugins.extras.lang.typescript.oxc",
+      "is_nested": true,
+      "name": "typescript.oxc"
+    },
+    "typescript.tsgo": {
+      "category": "lang",
+      "import": "lazyvim.plugins.extras.lang.typescript.tsgo",
+      "is_nested": true,
+      "name": "typescript.tsgo"
+    },
+    "typescript.vtsls": {
+      "category": "lang",
+      "import": "lazyvim.plugins.extras.lang.typescript.vtsls",
+      "is_nested": true,
+      "name": "typescript.vtsls"
     },
     "typst": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.typst",
+      "is_nested": false,
       "name": "typst"
     },
     "vue": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.vue",
+      "is_nested": false,
       "name": "vue"
     },
     "yaml": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.yaml",
+      "is_nested": false,
       "name": "yaml"
     },
     "zig": {
       "category": "lang",
       "import": "lazyvim.plugins.extras.lang.zig",
+      "is_nested": false,
       "name": "zig"
     }
   },
@@ -455,6 +567,7 @@
     "eslint": {
       "category": "linting",
       "import": "lazyvim.plugins.extras.linting.eslint",
+      "is_nested": false,
       "name": "eslint"
     }
   },
@@ -462,11 +575,13 @@
     "neoconf": {
       "category": "lsp",
       "import": "lazyvim.plugins.extras.lsp.neoconf",
+      "is_nested": false,
       "name": "neoconf"
     },
     "none_ls": {
       "category": "lsp",
       "import": "lazyvim.plugins.extras.lsp.none-ls",
+      "is_nested": false,
       "name": "none-ls"
     }
   },
@@ -474,6 +589,7 @@
     "core": {
       "category": "test",
       "import": "lazyvim.plugins.extras.test.core",
+      "is_nested": false,
       "name": "core"
     }
   },
@@ -481,46 +597,55 @@
     "alpha": {
       "category": "ui",
       "import": "lazyvim.plugins.extras.ui.alpha",
+      "is_nested": false,
       "name": "alpha"
     },
     "dashboard_nvim": {
       "category": "ui",
       "import": "lazyvim.plugins.extras.ui.dashboard-nvim",
+      "is_nested": false,
       "name": "dashboard-nvim"
     },
     "edgy": {
       "category": "ui",
       "import": "lazyvim.plugins.extras.ui.edgy",
+      "is_nested": false,
       "name": "edgy"
     },
     "indent_blankline": {
       "category": "ui",
       "import": "lazyvim.plugins.extras.ui.indent-blankline",
+      "is_nested": false,
       "name": "indent-blankline"
     },
     "mini_animate": {
       "category": "ui",
       "import": "lazyvim.plugins.extras.ui.mini-animate",
+      "is_nested": false,
       "name": "mini-animate"
     },
     "mini_indentscope": {
       "category": "ui",
       "import": "lazyvim.plugins.extras.ui.mini-indentscope",
+      "is_nested": false,
       "name": "mini-indentscope"
     },
     "mini_starter": {
       "category": "ui",
       "import": "lazyvim.plugins.extras.ui.mini-starter",
+      "is_nested": false,
       "name": "mini-starter"
     },
     "smear_cursor": {
       "category": "ui",
       "import": "lazyvim.plugins.extras.ui.smear-cursor",
+      "is_nested": false,
       "name": "smear-cursor"
     },
     "treesitter_context": {
       "category": "ui",
       "import": "lazyvim.plugins.extras.ui.treesitter-context",
+      "is_nested": false,
       "name": "treesitter-context"
     }
   },
@@ -528,46 +653,55 @@
     "chezmoi": {
       "category": "util",
       "import": "lazyvim.plugins.extras.util.chezmoi",
+      "is_nested": false,
       "name": "chezmoi"
     },
     "dot": {
       "category": "util",
       "import": "lazyvim.plugins.extras.util.dot",
+      "is_nested": false,
       "name": "dot"
     },
     "gh": {
       "category": "util",
       "import": "lazyvim.plugins.extras.util.gh",
+      "is_nested": false,
       "name": "gh"
     },
     "gitui": {
       "category": "util",
       "import": "lazyvim.plugins.extras.util.gitui",
+      "is_nested": false,
       "name": "gitui"
     },
     "mini_hipatterns": {
       "category": "util",
       "import": "lazyvim.plugins.extras.util.mini-hipatterns",
+      "is_nested": false,
       "name": "mini-hipatterns"
     },
     "octo": {
       "category": "util",
       "import": "lazyvim.plugins.extras.util.octo",
+      "is_nested": false,
       "name": "octo"
     },
     "project": {
       "category": "util",
       "import": "lazyvim.plugins.extras.util.project",
+      "is_nested": false,
       "name": "project"
     },
     "rest": {
       "category": "util",
       "import": "lazyvim.plugins.extras.util.rest",
+      "is_nested": false,
       "name": "rest"
     },
     "startuptime": {
       "category": "util",
       "import": "lazyvim.plugins.extras.util.startuptime",
+      "is_nested": false,
       "name": "startuptime"
     }
   }

--- a/nix/lib/dependencies.nix
+++ b/nix/lib/dependencies.nix
@@ -49,8 +49,7 @@
             # Split "category.name" into parts to access cfg.extras
             parts = lib.splitString "." extraName;
             category = lib.head parts;
-            name = lib.last parts;
-            extraConfig = cfg.extras.${category}.${name} or {};
+            extraConfig = lib.attrByPath (lib.tail parts) {} cfg.extras.${category};
             extraTools = dependencies.extras.${extraName} or [];
 
             # Check installation options

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -34,31 +34,53 @@ let
   # Helper function to collect enabled extras
   getEnabledExtras = extrasConfig:
     let
+      flattenExtras = categoryName: prefix: node:
+        let
+          isExtraEnabled = node.enable or false;
+          current = if isExtraEnabled then [{
+            name = prefix;
+            config = node.config or "";
+          }] else
+             [];
+          metaChildren = lib.filterAttrs(n: v:
+            builtins.isAttrs v && (v.is_nested or false) && lib.hasPrefix "${prefix}." n
+          ) (dataLib.extrasMetadata.${categoryName} or {});
+          nestedList = lib.mapAttrsToList (childName: _childConfig:
+            let
+              shortName = lib.removePrefix "${prefix}." childName;
+              nixName = builtins.replaceStrings ["_"] ["-"] shortName;
+              childNode = node.${nixName} or {};
+            in
+              flattenExtras categoryName childName childNode
+          ) metaChildren;
+        in current ++ builtins.concatLists nestedList;
+
       processCategory = categoryName: categoryExtras:
         let
-          enabledInCategory = lib.filterAttrs (extraName: extraConfig:
-            extraConfig.enable or false
-          ) categoryExtras;
-        in
-          lib.mapAttrsToList (extraName: extraConfig:
+          flatUserExtras = builtins.concatLists (lib.mapAttrsToList (topName: topConfig:
             let
-              # Normalize hyphens to underscores to match extras.json keys
-              normalizedName = builtins.replaceStrings ["-"] ["_"] extraName;
-              metadata = dataLib.extrasMetadata.${categoryName}.${normalizedName} or null;
+              normalizedName = builtins.replaceStrings ["-"] ["_"] topName;
+            in
+              flattenExtras categoryName normalizedName topConfig
+          ) categoryExtras);
+
+          resolvedExtras = map (item:
+            let
+              configPath = [ categoryName item.name ];
+              metadata = lib.attrByPath configPath null dataLib.extrasMetadata;
             in
               if metadata != null then {
                 inherit (metadata) name category import;
-                config = extraConfig.config or "";
-                hasConfig = (extraConfig.config or "") != "";
+                inherit (item) config;
+                hasConfig = item.config != "";
               } else
                 null
-          ) enabledInCategory;
+          ) flatUserExtras;
+        in builtins.filter (x: x != null) resolvedExtras;
 
       allCategories = lib.mapAttrsToList processCategory extrasConfig;
-      flattenedExtras = lib.flatten allCategories;
-      validExtras = lib.filter (x: x != null) flattenedExtras;
     in
-      validExtras;
+      lib.filter (x: x != null) (lib.flatten allCategories);
 
   # Get list of enabled extras
   enabledExtras = if cfg.enable then getEnabledExtras (cfg.extras or {}) else [];
@@ -187,7 +209,7 @@ let
 
 in {
   # Import module options
-  options.programs.lazyvim = import ./options.nix { inherit lib; };
+  options.programs.lazyvim = import ./options.nix { inherit lib dataLib; };
 
   config = mkIf cfg.enable {
     # Force evaluation of conflict checks (this will throw if conflicts exist)

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -1,5 +1,5 @@
 # Options definition for LazyVim Nix module
-{ lib }:
+{ lib, dataLib }:
 
 with lib;
 
@@ -160,96 +160,124 @@ with lib;
     '';
   };
 
-  extras = mkOption {
-    type = types.attrsOf (types.attrsOf (types.submodule {
-      options = {
+  extras = 
+    let
+      extraBaseOptions = {
         enable = mkEnableOption "this LazyVim extra";
-
         installDependencies = mkOption {
           type = types.bool;
           default = false;
-          description = ''
-            Whether to install the main tools for this extra.
-
-            For example, for lang.python this would install tools like 'ruff'.
-            When false (default), tools must be provided via extraPackages.
-          '';
+          description = "Whether to install the main tools for this extra.";
         };
-
         installRuntimeDependencies = mkOption {
           type = types.bool;
           default = false;
-          description = ''
-            Whether to install runtime dependencies for this extra's tools.
-
-            For example, for lang.python this would install python3 and pip.
-            When false (default), runtime dependencies must be available in PATH
-            or provided via extraPackages.
-          '';
+          description = "Whether to install runtime dependencies for this extra's tools.";
         };
-
         config = mkOption {
           type = types.str;
           default = "";
-          description = ''
-            Complete Lua plugin specification to override or extend this extra.
-            Should contain a complete lazy.nvim plugin spec with return statement.
-          '';
+          description = "Complete Lua plugin specification to override or extend this extra.";
         };
       };
-    }));
-    default = {};
-    example = literalExpression ''
-      {
-        coding.yanky = {
-          enable = true;
-          config = '''
-            return {
-              "gbprod/yanky.nvim",
-              opts = {
-                highlight = { timer = 300 },
-              },
-            }
-          ''';
-        };
 
-        lang.python = {
-          enable = true;
-          installDependencies = true;        # Install ruff
-          installRuntimeDependencies = true; # Install python3, pip
-        };
+      mkCategoryOptions = categoryExtras:
+        let
+          nixifyName = replaceStrings ["_"] ["-"];
 
-        lang.go = {
-          enable = true;
-          installDependencies = true;        # Install gopls, gofumpt, etc.
-          installRuntimeDependencies = true; # Install go compiler
-        };
+          parents = filterAttrs (_: v: !(v.is_nested or false)) categoryExtras;
+          nested  = filterAttrs (_: v:   v.is_nested or false)  categoryExtras;
 
-        lang.nix = {
-          enable = true;
-          config = '''
-            return {
-              "neovim/nvim-lspconfig",
-              opts = {
-                servers = {
-                  nixd = {},
-                },
-              },
-            }
-          ''';
-        };
+          childrenOf = parentName:
+            filterAttrs (n: _: hasPrefix "${parentName}." n) nested;
 
-        editor.dial.enable = true;
-      }
-    '';
-    description = ''
-      LazyVim extras to enable. Extras provide additional plugins and configurations
-      for specific languages, features, or tools.
+          mkExtraSubmodule = name: _meta:
+            let
+              children = childrenOf name;
+              childOpts = mapAttrs' (qualifiedName: _:
+                let
+                  shortName = removePrefix "${name}." qualifiedName;
+                in nameValuePair (nixifyName shortName) (mkOption {
+                  type    = types.submodule { options = extraBaseOptions; };
+                  default = {};
+                  description = "Nested extra: ${qualifiedName}";
+                })
+              ) children;
+            in mkOption {
+              type    = types.submodule { options = extraBaseOptions // childOpts; };
+              default = {};
+              description = "LazyVim extra: ${name}";
+            };
+        in
+          mapAttrs' (jsonKey: meta:
+            nameValuePair (nixifyName jsonKey) (mkExtraSubmodule jsonKey meta)
+          ) parents;
 
-      Each extra can be enabled with `enable = true` and optionally configured with
-      complete lazy.nvim plugin specifications in the `config` field.
-    '';
-  };
+      # Top-level: one submodule per category
+      generatedExtrasType = types.submodule {
+        options = mapAttrs (categoryName: categoryExtras:
+          mkOption {
+            type    = types.submodule { options = mkCategoryOptions categoryExtras; };
+            default = {};
+            description = "LazyVim ${categoryName} extras.";
+          }
+        ) dataLib.extrasMetadata;
+      };
+    in
+      mkOption {
+        type = generatedExtrasType;
+        default = {};
+        example = literalExpression ''
+          {
+            coding.yanky = {
+              enable = true;
+              config = '''
+                return {
+                  "gbprod/yanky.nvim",
+                  opts = {
+                    highlight = { timer = 300 },
+                  },
+                }
+              ''';
+            };
+
+            lang.python = {
+              enable = true;
+              installDependencies = true;        # Install ruff
+              installRuntimeDependencies = true; # Install python3, pip
+            };
+
+            lang.go = {
+              enable = true;
+              installDependencies = true;        # Install gopls, gofumpt, etc.
+              installRuntimeDependencies = true; # Install go compiler
+            };
+
+            lang.nix = {
+              enable = true;
+              config = '''
+                return {
+                  "neovim/nvim-lspconfig",
+                  opts = {
+                    servers = {
+                      nixd = {},
+                    },
+                  },
+                }
+              ''';
+            };
+
+            editor.dial.enable = true;
+          }
+        '';
+        description = ''
+          LazyVim extras to enable. Extras provide additional plugins and configurations
+          for specific languages, features, or tools.
+
+          Each extra can be enabled with `enable = true` and optionally configured with
+          complete lazy.nvim plugin specifications in the `config` field.
+        '';
+    };
 
   ignoreBuildNotifications = mkOption {
     type = types.bool;

--- a/scripts/extract-dependencies.lua
+++ b/scripts/extract-dependencies.lua
@@ -411,6 +411,7 @@ local function resolve_package_name(dep_name)
         gleam = "gleam",
         tinymist = "tinymist",
         ["haskell-language-server"] = "haskell-language-server",
+        jsonls = "vscode-langservers-extracted",
 
         -- Go tools with direct names
         gopls = "gopls",
@@ -430,6 +431,12 @@ local function resolve_package_name(dep_name)
         -- Node packages (top-level in nixpkgs)
         prettier = "prettier",
         eslint = "eslint",
+        biome = "biome",
+        oxlint = "oxlint",
+        oxfmt = "oxfmt",
+        tsgo = "typescript-go",
+        tsgolint = "tsgolint",
+        vtsls = "vtsls",
 
         -- Debug adapters
         codelldb = "vscode-extensions.vadimcn.vscode-lldb",

--- a/scripts/generate-extras-metadata.lua
+++ b/scripts/generate-extras-metadata.lua
@@ -55,6 +55,7 @@ local function main()
         extras_data[category][key_name] = {
           name = extra_name,
           category = category,
+          is_nested = false,
           import = string.format("lazyvim.plugins.extras.%s.%s", category, extra_name)
         }
         total_count = total_count + 1
@@ -66,14 +67,21 @@ local function main()
 
       for _, subdir in ipairs(subdirs) do
         if vim.fn.isdirectory(subdir) == 1 then
-          local init_file = subdir .. "/init.lua"
-          if vim.fn.filereadable(init_file) == 1 then
+          local extra_paths = vim.fn.glob(subdir .. "/*.lua", false, true)
+          for _, extra_path in ipairs(extra_paths) do
+            local extra_file = vim.fn.fnamemodify(extra_path, ":t")
             local extra_name = vim.fn.fnamemodify(subdir, ":t")
+            local is_nested = extra_file ~= "init.lua"
+            if is_nested then
+              local subextra_name = vim.fn.fnamemodify(extra_file, ":r")
+              extra_name = string.format("%s.%s", extra_name, subextra_name)
+            end
             local key_name = extra_name:gsub("-", "_")
 
             extras_data[category][key_name] = {
               name = extra_name,
               category = category,
+              is_nested = is_nested,
               import = string.format("lazyvim.plugins.extras.%s.%s", category, extra_name)
             }
             total_count = total_count + 1

--- a/test/default.nix
+++ b/test/default.nix
@@ -70,7 +70,8 @@ let
   unitTests = import ./unit { inherit pkgs testLib moduleUnderTest; };
   integrationTests = import ./integration/simple.nix { inherit pkgs testLib moduleUnderTest; } //
                      import ./integration/critical.nix { inherit pkgs testLib moduleUnderTest; } //
-                     import ./integration/issue33-fix.nix { inherit pkgs testLib moduleUnderTest; };
+                     import ./integration/issue33-fix.nix { inherit pkgs testLib moduleUnderTest; } //
+                     import ./integration/nested-extras.nix { inherit pkgs testLib moduleUnderTest; };
   propertyTests = import ./property/simple.nix { inherit pkgs testLib moduleUnderTest; };
   regressionTests = import ./regression/simple.nix { inherit pkgs testLib moduleUnderTest; } //
                     import ./regression/lazyvim-compliance.nix { inherit pkgs testLib moduleUnderTest; } //

--- a/test/integration/nested-extras.nix
+++ b/test/integration/nested-extras.nix
@@ -1,0 +1,611 @@
+# Tests for nested extras support (e.g., lang.typescript.biome, lang.typescript.oxc)
+{ pkgs, testLib, moduleUnderTest }:
+
+let
+  lib = pkgs.lib;
+
+in {
+
+  # ── Metadata structure ──────────────────────────────────────────────
+
+  # Test that extras.json contains nested typescript extras with is_nested flag
+  test-nested-extras-metadata-present = testLib.testNixExpr
+    "nested-extras-metadata-present"
+    ''
+      let
+        extras = builtins.fromJSON (builtins.readFile ${../../data/extras.json});
+        lang = extras.lang or {};
+        hasTypescript = lang ? typescript;
+        hasBiome = lang ? "typescript.biome";
+        hasOxc = lang ? "typescript.oxc";
+        hasTsgo = lang ? "typescript.tsgo";
+        hasVtsls = lang ? "typescript.vtsls";
+      in hasTypescript && hasBiome && hasOxc && hasTsgo && hasVtsls
+    ''
+    "true";
+
+  # Test that parent typescript extra has is_nested = false
+  test-nested-extras-parent-not-nested = testLib.testNixExpr
+    "nested-extras-parent-not-nested"
+    ''
+      let
+        extras = builtins.fromJSON (builtins.readFile ${../../data/extras.json});
+        ts = extras.lang.typescript;
+      in ts.is_nested == false
+    ''
+    "true";
+
+  # Test that child extras have is_nested = true
+  test-nested-extras-children-nested = testLib.testNixExpr
+    "nested-extras-children-nested"
+    ''
+      let
+        extras = builtins.fromJSON (builtins.readFile ${../../data/extras.json});
+        biome = extras.lang."typescript.biome";
+        oxc = extras.lang."typescript.oxc";
+        tsgo = extras.lang."typescript.tsgo";
+        vtsls = extras.lang."typescript.vtsls";
+      in biome.is_nested && oxc.is_nested && tsgo.is_nested && vtsls.is_nested
+    ''
+    "true";
+
+  # Test that nested extras have correct import paths
+  test-nested-extras-import-paths = testLib.testNixExpr
+    "nested-extras-import-paths"
+    ''
+      let
+        extras = builtins.fromJSON (builtins.readFile ${../../data/extras.json});
+        biome = extras.lang."typescript.biome";
+        oxc = extras.lang."typescript.oxc";
+        tsgo = extras.lang."typescript.tsgo";
+        vtsls = extras.lang."typescript.vtsls";
+      in biome.import == "lazyvim.plugins.extras.lang.typescript.biome"
+         && oxc.import == "lazyvim.plugins.extras.lang.typescript.oxc"
+         && tsgo.import == "lazyvim.plugins.extras.lang.typescript.tsgo"
+         && vtsls.import == "lazyvim.plugins.extras.lang.typescript.vtsls"
+    ''
+    "true";
+
+  # Test that parent typescript has correct import path
+  test-nested-extras-parent-import-path = testLib.testNixExpr
+    "nested-extras-parent-import-path"
+    ''
+      let
+        extras = builtins.fromJSON (builtins.readFile ${../../data/extras.json});
+        ts = extras.lang.typescript;
+      in ts.import == "lazyvim.plugins.extras.lang.typescript"
+    ''
+    "true";
+
+  # ── Option type generation (module evaluates without error) ─────────
+
+  # Test that the generated options type accepts a nested extra
+  test-nested-extras-options-eval = testLib.testNixExpr
+    "nested-extras-options-eval"
+    ''
+      let
+        testConfig = {
+          config = {
+            home.homeDirectory = "/tmp/test";
+            home.username = "testuser";
+            home.stateVersion = "23.11";
+            programs.lazyvim = {
+              enable = true;
+              extras = {
+                lang.typescript = {
+                  enable = true;
+                  biome.enable = true;
+                };
+              };
+            };
+          };
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+        };
+        module = import ${../../nix/module.nix} testConfig;
+      in builtins.isAttrs module
+    ''
+    "true";
+
+  # Test enabling a nested extra without enabling its parent
+  test-nested-extras-child-without-parent = testLib.testNixExpr
+    "nested-extras-child-without-parent"
+    ''
+      let
+        testConfig = {
+          config = {
+            home.homeDirectory = "/tmp/test";
+            home.username = "testuser";
+            home.stateVersion = "23.11";
+            programs.lazyvim = {
+              enable = true;
+              extras = {
+                lang.typescript = {
+                  enable = false;
+                  biome.enable = true;
+                };
+              };
+            };
+          };
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+        };
+        module = import ${../../nix/module.nix} testConfig;
+      in builtins.isAttrs module
+    ''
+    "true";
+
+  # Test enabling parent without any nested children
+  test-nested-extras-parent-only = testLib.testNixExpr
+    "nested-extras-parent-only"
+    ''
+      let
+        testConfig = {
+          config = {
+            home.homeDirectory = "/tmp/test";
+            home.username = "testuser";
+            home.stateVersion = "23.11";
+            programs.lazyvim = {
+              enable = true;
+              extras = {
+                lang.typescript.enable = true;
+              };
+            };
+          };
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+        };
+        module = import ${../../nix/module.nix} testConfig;
+      in builtins.isAttrs module
+    ''
+    "true";
+
+  # Test enabling all four nested children simultaneously
+  test-nested-extras-all-children = testLib.testNixExpr
+    "nested-extras-all-children"
+    ''
+      let
+        testConfig = {
+          config = {
+            home.homeDirectory = "/tmp/test";
+            home.username = "testuser";
+            home.stateVersion = "23.11";
+            programs.lazyvim = {
+              enable = true;
+              extras = {
+                lang.typescript = {
+                  enable = true;
+                  biome.enable = true;
+                  oxc.enable = true;
+                  tsgo.enable = true;
+                  vtsls.enable = true;
+                };
+              };
+            };
+          };
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+        };
+        module = import ${../../nix/module.nix} testConfig;
+      in builtins.isAttrs module
+    ''
+    "true";
+
+  # Test nested extra with all sub-options populated
+  test-nested-extras-suboptions-complete = testLib.testNixExpr
+    "nested-extras-suboptions-complete"
+    ''
+      let
+        testConfig = {
+          config = {
+            home.homeDirectory = "/tmp/test";
+            home.username = "testuser";
+            home.stateVersion = "23.11";
+            programs.lazyvim = {
+              enable = true;
+              extras = {
+                lang.typescript = {
+                  enable = true;
+                  installDependencies = true;
+                  installRuntimeDependencies = true;
+                  config = "";
+                  biome = {
+                    enable = true;
+                    installDependencies = true;
+                    installRuntimeDependencies = true;
+                    config = "return {}";
+                  };
+                };
+              };
+            };
+          };
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+        };
+        module = import ${../../nix/module.nix} testConfig;
+      in builtins.isAttrs module
+    ''
+    "true";
+
+  # Test mixing nested and non-nested extras in the same config
+  test-nested-extras-mixed-config = testLib.testNixExpr
+    "nested-extras-mixed-config"
+    ''
+      let
+        testConfig = {
+          config = {
+            home.homeDirectory = "/tmp/test";
+            home.username = "testuser";
+            home.stateVersion = "23.11";
+            programs.lazyvim = {
+              enable = true;
+              extras = {
+                lang = {
+                  python.enable = true;
+                  nix.enable = true;
+                  typescript = {
+                    enable = true;
+                    biome.enable = true;
+                  };
+                };
+                editor.telescope.enable = true;
+                coding.yanky.enable = true;
+              };
+            };
+          };
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+        };
+        module = import ${../../nix/module.nix} testConfig;
+      in builtins.isAttrs module
+    ''
+    "true";
+
+  # Test non-nested extras are unaffected by nested extras changes
+  test-nested-extras-non-nested-unaffected = testLib.testNixExpr
+    "nested-extras-non-nested-unaffected"
+    ''
+      let
+        testConfig = {
+          config = {
+            home.homeDirectory = "/tmp/test";
+            home.username = "testuser";
+            home.stateVersion = "23.11";
+            programs.lazyvim = {
+              enable = true;
+              extras = {
+                lang = {
+                  python.enable = true;
+                  go.enable = true;
+                  rust.enable = true;
+                };
+                editor.telescope.enable = true;
+              };
+            };
+          };
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+        };
+        module = import ${../../nix/module.nix} testConfig;
+      in builtins.isAttrs module
+    ''
+    "true";
+
+  # ── flattenExtras / getEnabledExtras logic ──────────────────────────
+  # Test the core flattening logic by reimplementing it inline with mock data,
+  # which lets us inspect the output without needing the full module system.
+
+  # Test that flattenExtras produces entries for both parent and children
+  test-nested-extras-flatten-parent-and-children = testLib.testNixExpr
+    "nested-extras-flatten-parent-and-children"
+    ''
+      let
+        lib = (import <nixpkgs> {}).lib;
+        extrasMetadata = builtins.fromJSON (builtins.readFile ${../../data/extras.json});
+
+        normalizeName = builtins.replaceStrings ["-"] ["_"];
+
+        flattenExtras = categoryName: prefix: node:
+          let
+            isExtraEnabled = node.enable or false;
+            current = if isExtraEnabled then [{
+              name = prefix;
+              config = node.config or "";
+            }] else [];
+            metaChildren = lib.filterAttrs (n: v:
+              builtins.isAttrs v && (v.is_nested or false) && lib.hasPrefix "''${prefix}." n
+            ) (extrasMetadata.''${categoryName} or {});
+            nestedList = lib.mapAttrsToList (childName: _childConfig:
+              let
+                shortName = lib.removePrefix "''${prefix}." childName;
+                normalizedName = normalizeName shortName;
+                childNode = node.''${normalizedName} or {};
+              in
+                flattenExtras categoryName childName childNode
+            ) metaChildren;
+          in current ++ builtins.concatLists nestedList;
+
+        # Simulate: typescript.enable = true, biome.enable = true, oxc.enable = false
+        mockNode = {
+          enable = true;
+          config = "";
+          biome = { enable = true; config = ""; };
+          oxc = { enable = false; config = ""; };
+          tsgo = { config = ""; };
+          vtsls = { config = ""; };
+        };
+
+        result = flattenExtras "lang" "typescript" mockNode;
+        names = map (r: r.name) result;
+
+        hasParent = builtins.elem "typescript" names;
+        hasBiome = builtins.elem "typescript.biome" names;
+        hasOxc = builtins.elem "typescript.oxc" names;
+        hasTsgo = builtins.elem "typescript.tsgo" names;
+      in hasParent && hasBiome && !hasOxc && !hasTsgo
+    ''
+    "true";
+
+  # Test that flattenExtras produces nothing when all disabled
+  test-nested-extras-flatten-all-disabled = testLib.testNixExpr
+    "nested-extras-flatten-all-disabled"
+    ''
+      let
+        lib = (import <nixpkgs> {}).lib;
+        extrasMetadata = builtins.fromJSON (builtins.readFile ${../../data/extras.json});
+
+        normalizeName = builtins.replaceStrings ["-"] ["_"];
+
+        flattenExtras = categoryName: prefix: node:
+          let
+            isExtraEnabled = node.enable or false;
+            current = if isExtraEnabled then [{
+              name = prefix;
+              config = node.config or "";
+            }] else [];
+            metaChildren = lib.filterAttrs (n: v:
+              builtins.isAttrs v && (v.is_nested or false) && lib.hasPrefix "''${prefix}." n
+            ) (extrasMetadata.''${categoryName} or {});
+            nestedList = lib.mapAttrsToList (childName: _childConfig:
+              let
+                shortName = lib.removePrefix "''${prefix}." childName;
+                normalizedName = normalizeName shortName;
+                childNode = node.''${normalizedName} or {};
+              in
+                flattenExtras categoryName childName childNode
+            ) metaChildren;
+          in current ++ builtins.concatLists nestedList;
+
+        mockNode = {
+          enable = false;
+          config = "";
+        };
+
+        result = flattenExtras "lang" "typescript" mockNode;
+      in builtins.length result == 0
+    ''
+    "true";
+
+  # Test that flattenExtras handles child-only enable (parent disabled)
+  test-nested-extras-flatten-child-only = testLib.testNixExpr
+    "nested-extras-flatten-child-only"
+    ''
+      let
+        lib = (import <nixpkgs> {}).lib;
+        extrasMetadata = builtins.fromJSON (builtins.readFile ${../../data/extras.json});
+
+        normalizeName = builtins.replaceStrings ["-"] ["_"];
+
+        flattenExtras = categoryName: prefix: node:
+          let
+            isExtraEnabled = node.enable or false;
+            current = if isExtraEnabled then [{
+              name = prefix;
+              config = node.config or "";
+            }] else [];
+            metaChildren = lib.filterAttrs (n: v:
+              builtins.isAttrs v && (v.is_nested or false) && lib.hasPrefix "''${prefix}." n
+            ) (extrasMetadata.''${categoryName} or {});
+            nestedList = lib.mapAttrsToList (childName: _childConfig:
+              let
+                shortName = lib.removePrefix "''${prefix}." childName;
+                normalizedName = normalizeName shortName;
+                childNode = node.''${normalizedName} or {};
+              in
+                flattenExtras categoryName childName childNode
+            ) metaChildren;
+          in current ++ builtins.concatLists nestedList;
+
+        mockNode = {
+          enable = false;
+          config = "";
+          biome = { enable = true; config = ""; };
+        };
+
+        result = flattenExtras "lang" "typescript" mockNode;
+        names = map (r: r.name) result;
+      in builtins.length result == 1 && builtins.elem "typescript.biome" names
+    ''
+    "true";
+
+  # Test that metadata resolution works for flattened nested extras
+  test-nested-extras-metadata-resolution = testLib.testNixExpr
+    "nested-extras-metadata-resolution"
+    ''
+      let
+        lib = (import <nixpkgs> {}).lib;
+        extrasMetadata = builtins.fromJSON (builtins.readFile ${../../data/extras.json});
+
+        item = { name = "typescript.biome"; config = ""; };
+        path = [ "lang" item.name ];
+        metadata = lib.attrByPath path null extrasMetadata;
+
+        hasMetadata = metadata != null;
+        correctImport = metadata.import == "lazyvim.plugins.extras.lang.typescript.biome";
+        correctCategory = metadata.category == "lang";
+      in hasMetadata && correctImport && correctCategory
+    ''
+    "true";
+
+  # Test metadata resolution for parent extra
+  test-nested-extras-parent-metadata-resolution = testLib.testNixExpr
+    "nested-extras-parent-metadata-resolution"
+    ''
+      let
+        lib = (import <nixpkgs> {}).lib;
+        extrasMetadata = builtins.fromJSON (builtins.readFile ${../../data/extras.json});
+
+        item = { name = "typescript"; config = ""; };
+        path = [ "lang" item.name ];
+        metadata = lib.attrByPath path null extrasMetadata;
+
+        hasMetadata = metadata != null;
+        correctImport = metadata.import == "lazyvim.plugins.extras.lang.typescript";
+      in hasMetadata && correctImport
+    ''
+    "true";
+
+  # ── Import spec generation ──────────────────────────────────────────
+
+  # Test that extrasImportSpecs produces correct Lua import strings
+  test-nested-extras-import-spec-format = testLib.testNixExpr
+    "nested-extras-import-spec-format"
+    ''
+      let
+        lib = (import <nixpkgs> {}).lib;
+
+        mockExtras = [
+          { name = "typescript"; category = "lang";
+            import = "lazyvim.plugins.extras.lang.typescript";
+            config = ""; hasConfig = false; }
+          { name = "typescript.biome"; category = "lang";
+            import = "lazyvim.plugins.extras.lang.typescript.biome";
+            config = ""; hasConfig = false; }
+        ];
+
+        importSpecs = map (extra:
+          "{ import = \"''${extra.import}\" },"
+        ) mockExtras;
+
+        hasTs = builtins.any (s:
+          builtins.match ".*lazyvim.plugins.extras.lang.typescript\".*" s != null
+        ) importSpecs;
+        hasBiome = builtins.any (s:
+          builtins.match ".*lazyvim.plugins.extras.lang.typescript.biome.*" s != null
+        ) importSpecs;
+      in builtins.length importSpecs == 2 && hasTs && hasBiome
+    ''
+    "true";
+
+  # ── Dependencies data structure ─────────────────────────────────────
+
+  # Test that dependencies.json has entries for nested typescript extras
+  test-nested-extras-dependencies-exist = testLib.testNixExpr
+    "nested-extras-dependencies-exist"
+    ''
+      let
+        deps = builtins.fromJSON (builtins.readFile ${../../data/dependencies.json});
+        extras = deps.extras or {};
+        hasBiome = extras ? "lang.typescript.biome";
+        hasOxc = extras ? "lang.typescript.oxc";
+        hasTsgo = extras ? "lang.typescript.tsgo";
+        hasVtsls = extras ? "lang.typescript.vtsls";
+      in hasBiome && hasOxc && hasTsgo && hasVtsls
+    ''
+    "true";
+
+  # Test that nested dependency entries have nixpkg mappings
+  test-nested-extras-nixpkg-mappings = testLib.testNixExpr
+    "nested-extras-nixpkg-mappings"
+    ''
+      let
+        deps = builtins.fromJSON (builtins.readFile ${../../data/dependencies.json});
+        biomeTools = deps.extras."lang.typescript.biome" or [];
+        biomeHasNixpkg = builtins.any (t: t ? nixpkg) biomeTools;
+        oxcTools = deps.extras."lang.typescript.oxc" or [];
+        oxcHasNixpkg = builtins.any (t: t ? nixpkg) oxcTools;
+        tsgoTools = deps.extras."lang.typescript.tsgo" or [];
+        tsgoHasNixpkg = builtins.any (t: t ? nixpkg) tsgoTools;
+        vtslsTools = deps.extras."lang.typescript.vtsls" or [];
+        vtslsHasNixpkg = builtins.any (t: t ? nixpkg) vtslsTools;
+      in biomeHasNixpkg && oxcHasNixpkg && tsgoHasNixpkg && vtslsHasNixpkg
+    ''
+    "true";
+
+  # ── Dependency resolution bug detection ─────────────────────────────
+  # dependencies.nix uses lib.head/lib.last to split the extra name, which loses
+  # the middle component for nested extras like "lang.typescript.biome".
+  # These tests verify the config lookup logic independent of the full module system.
+
+  # Test that the correct config lookup path is needed for nested extras
+  test-nested-extras-dep-config-lookup = testLib.testNixExpr
+    "nested-extras-dep-config-lookup"
+    ''
+      let
+        lib = (import <nixpkgs> {}).lib;
+
+        # Simulate the cfg.extras structure as the module would produce it
+        extrasConfig = {
+          lang = {
+            typescript = {
+              enable = true;
+              installDependencies = false;
+              installRuntimeDependencies = false;
+              biome = {
+                enable = true;
+                installDependencies = true;
+                installRuntimeDependencies = true;
+              };
+            };
+          };
+        };
+
+        extraName = "lang.typescript.biome";
+        parts = lib.splitString "." extraName;
+        category = lib.head parts;
+
+        # CORRECT approach: use attrByPath for the remainder
+        correctConfig = lib.attrByPath (lib.tail parts) {} extrasConfig.''${category};
+        correctInstallDeps = correctConfig.installDependencies or false;
+
+        # BUGGY approach: use lib.last (loses "typescript" component)
+        buggyName = lib.last parts;
+        buggyConfig = extrasConfig.''${category}.''${buggyName} or {};
+        buggyInstallDeps = buggyConfig.installDependencies or false;
+
+      in correctInstallDeps == true && buggyInstallDeps == false
+    ''
+    "true";
+
+  # Same test for a non-nested extra to show the bug doesn't affect them
+  test-nested-extras-dep-config-lookup-simple = testLib.testNixExpr
+    "nested-extras-dep-config-lookup-simple"
+    ''
+      let
+        lib = (import <nixpkgs> {}).lib;
+
+        extrasConfig = {
+          lang = {
+            python = {
+              enable = true;
+              installDependencies = true;
+            };
+          };
+        };
+
+        extraName = "lang.python";
+        parts = lib.splitString "." extraName;
+        category = lib.head parts;
+
+        # Both approaches work for non-nested extras
+        correctConfig = lib.attrByPath (lib.tail parts) {} extrasConfig.''${category};
+        buggyName = lib.last parts;
+        buggyConfig = extrasConfig.''${category}.''${buggyName} or {};
+
+        correctInstallDeps = correctConfig.installDependencies or false;
+        buggyInstallDeps = buggyConfig.installDependencies or false;
+
+      in correctInstallDeps == true && buggyInstallDeps == true
+    ''
+    "true";
+}


### PR DESCRIPTION
## What?

1. Now supports nested extras (extras in subdirectories aside from `init.lua`, like `typescript/biome.lua`)
2. Generates extras option types from `extras.json` instead of using an open `attrsOf`. This catches typos and invalid extra names at evaluation time.
3. Adds a few missing mappings for the TS ecosystem - `jsonls`, `biome`, `tsgo`, `oxlint`, `oxfmt`, `tsgolint`

## Why?

- Without this update, it is not possible to use `biome` or `oxc` with `typescript`. Given that the community is moving towards native toolchains, this is a blocker.
- Improved type safety.

## Breaking

- Mistyped or forward-looking keys in the extras config will now hard-error instead of silently dropping. Arguably an improvement. I had a few mistyped extras I had recently added and not yet noticed.

See: <https://github.com/LazyVim/LazyVim/releases/tag/v15.15.0>
