### PR TITLE
fix: string-mapped plugins fail nixpkgs lookup due to vimPlugins prefix

### DIFF
--- a/data/mappings.json
+++ b/data/mappings.json
@@ -1,12 +1,12 @@
 {
-  "catppuccin/nvim": "vimPlugins.catppuccin-nvim",
-  "saghen/blink.cmp": "vimPlugins.blink-cmp",
-  "saghen/blink.compat": "vimPlugins.blink-compat",
+  "catppuccin/nvim": "catppuccin-nvim",
+  "saghen/blink.cmp": "blink-cmp",
+  "saghen/blink.compat": "blink-compat",
   "echasnovski/mini.icons": {
     "package": "mini-nvim",
     "module": "mini.icons"
   },
-  "mfussenegger/nvim-ansible": "vimPlugins.ansible-vim",
+  "mfussenegger/nvim-ansible": "ansible-vim",
   "nvim-mini/mini.ai": {
     "package": "mini-nvim",
     "module": "mini.ai"
@@ -47,8 +47,8 @@
     "package": "mini-nvim",
     "module": "mini.surround"
   },
-  "RRethy/vim-illuminate": "vimPlugins.vim-illuminate",
-  "tpope/vim-repeat": "vimPlugins.vim-repeat",
+  "RRethy/vim-illuminate": "vim-illuminate",
+  "tpope/vim-repeat": "vim-repeat",
   "tpope/vim-dadbod": "vim-dadbod",
   "kristijanhusak/vim-dadbod-completion": "vim-dadbod-completion",
   "kristijanhusak/vim-dadbod-ui": "vim-dadbod-ui",


### PR DESCRIPTION
I noticed blink-cmp wasn't being pulled in from nix. After looking through, found that the mappings were as follows:

https://github.com/pfassina/lazyvim-nix/blob/c1c27d9b3fd74d243a34985c5440a14aa0c2a169/data/mappings.json#L3

This then passes through here:

https://github.com/pfassina/lazyvim-nix/blob/c1c27d9b3fd74d243a34985c5440a14aa0c2a169/nix/lib/plugin-resolution.nix#L106

and makes the package this:

```
pkgs.vimPlugins."vimPlugins.blink-cmp"
```

I removed all the `vimPlugins` in the data mappings. Seems to work fine for me (other than catppuccin which I will submit a different PR for).