### PR TITLE
fix: nixpkgs strategy ignores available nix packages for wildcard versions

### DIFF
--- a/nix/lib/plugin-resolution.nix
+++ b/nix/lib/plugin-resolution.nix
@@ -127,6 +127,8 @@ let
       # Priority: respect LazyVim's exact specifications first
       targetVersion = if lazyvimVersion != null && lazyvimVersion != "*" && lazyvimVersion != false then
         lazyvimVersion
+      else if lazyvimVersion == "*" && cfg.pluginSource == "nixpkgs" then
+        lazyvimVersion
       else if tagVersion != null then
         tagVersion
       else if latestVersion != null then

--- a/nix/lib/plugin-resolution.nix
+++ b/nix/lib/plugin-resolution.nix
@@ -125,10 +125,9 @@ let
 
       # Determine target version based on LazyVim specifications
       # Priority: respect LazyVim's exact specifications first
-      targetVersion = if lazyvimVersion != null && lazyvimVersion != "*" && lazyvimVersion != false then
-        lazyvimVersion
-      else if lazyvimVersion == "*" && cfg.pluginSource == "nixpkgs" then
-        lazyvimVersion
+      targetVersion = if (lazyvimVersion != null && lazyvimVersion != "*" && lazyvimVersion != false)
+          || (lazyvimVersion == "*" && cfg.pluginSource == "nixpkgs")
+        then lazyvimVersion
       else if tagVersion != null then
         tagVersion
       else if latestVersion != null then


### PR DESCRIPTION
The first if block makes "*" lead to tag/latest/commit rather than set * for the next if block. This is fine for `pluginSource = "latest"`, but if you want nixpkgs then many plugins are via tag. In the case of blink-cmp at the moment, this leads to commit hash which doesn't match the nix package name.

https://github.com/pfassina/lazyvim-nix/blob/c1c27d9b3fd74d243a34985c5440a14aa0c2a169/nix/lib/plugin-resolution.nix#L126-L145

Hence, I have added a quick extra check for the pluginSource in this check to allow through '*' for the target version.