### PR TITLE
feat: add treesitterSource option independent of pluginSource

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -122,11 +122,11 @@ let
   extrasImportSpecs = configLib.extrasImportSpecs enabledExtras;
 
   # Treesitter configuration
-  # Select grammar source based on pluginSource strategy:
+  # Select grammar source based on treesitterSource option:
   # - "latest": Build parsers from source to match nvim-treesitter version
   # - "nixpkgs": Use nixpkgs grammarPlugins (current behavior)
   treesitterGrammars =
-    if cfg.pluginSource == "latest" && treesitterLib.hasParserRevisions then
+    if cfg.treesitterSource == "latest" && treesitterLib.hasParserRevisions then
       treesitterLib.treesitterGrammarsFromSource automaticTreesitterParsers
     else
       treesitterLib.treesitterGrammars automaticTreesitterParsers;

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -26,6 +26,16 @@ with lib;
     '';
   };
 
+  treesitterSource = mkOption {
+    type = types.enum [ "latest" "nixpkgs" ];
+    default = "latest";
+    description = ''
+      Treesitter parser source strategy, independent of pluginSource.
+      - "latest": Build parsers from source to match nvim-treesitter main branch queries
+      - "nixpkgs": Use nixpkgs grammar plugins
+    '';
+  };
+
   extraPackages = mkOption {
     type = types.listOf types.package;
     default = [];


### PR DESCRIPTION
As nixpkgs on 25.11 is still on the master branch for treesitter, this has made my config not work if I use `pluginSource = "nixpkgs"`. 

I know this is a short lived issue until next nixpkgs version, but I thought perhaps having an independent option to allow nvim-treesitter to be up to date might be wanted by some people. I certainly am wanting it at least in my own setup.