### PR TITLE
refactor(file-scanning): eliminate IFD in scanUserPlugins

### DIFF
--- a/nix/lib/file-scanning.nix
+++ b/nix/lib/file-scanning.nix
@@ -2,61 +2,39 @@
 { lib, pkgs, config }:
 
 {
-  # Function to scan user plugins from LazyVim configuration
   scanUserPlugins = config_path:
     let
-      # Use Nix to call the Lua scanner script
-      scanResult = pkgs.runCommand "scan-user-plugins" {
-        buildInputs = [ pkgs.lua pkgs.neovim pkgs.luaPackages.luv ];
-      } ''
-        # Copy scanner script to build directory
-        cp ${../../scripts/scan-user-plugins.lua} scan-user-plugins.lua
-
-        # Create a simple Lua runner script
-        cat > run-scanner.lua << 'EOF'
-        -- Initialize vim.loop for the scanner
-        _G.vim = _G.vim or {}
-        vim.loop = vim.loop or require('luv')
-
-        -- Load the scanner
-        local scanner = dofile('scan-user-plugins.lua')
-
-        -- Scan for user plugins
-        local user_plugins = scanner.scan_user_plugins("${config_path}")
-
-        -- Output as JSON-like format for Nix to parse
-        local function to_json_array(plugins)
-          local result = "["
-          for i, plugin in ipairs(plugins) do
-            if i > 1 then result = result .. "," end
-            result = result .. string.format(
-              '{"name":"%s","owner":"%s","repo":"%s","source_file":"%s","user_plugin":true}',
-              plugin.name, plugin.owner, plugin.repo, plugin.source_file
-            )
-          end
-          result = result .. "]"
-          return result
-        end
-
-        -- Write result to Nix output path
-        local output_path = os.getenv("out")
-        local file = io.open(output_path, "w")
-        file:write(to_json_array(user_plugins))
-        file:close()
-        EOF
-
-        # Default to empty array (handles early returns in Lua scanner)
-        echo "[]" > $out
-
-        # Run the scanner if config path exists (overwrites default on success)
-        if [ -d "${config_path}" ]; then
-          lua run-scanner.lua 2>/dev/null || true
-        fi
-      '';
-      userPluginsJson = builtins.readFile scanResult;
-      userPluginsList = if userPluginsJson == "[]" then [] else builtins.fromJSON userPluginsJson;
+      pluginsDir = config_path + "/lua/plugins";
     in
-      userPluginsList;
+      if !builtins.pathExists pluginsDir then []
+      else let
+        luaFiles = lib.filter
+          (p: lib.hasSuffix ".lua" (toString p))
+          (lib.filesystem.listFilesRecursive pluginsDir);
+
+        tokenRe = ''"([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)"'';
+
+        extractFromFile = p:
+          let
+            content = builtins.readFile p;
+            matches = builtins.filter builtins.isList
+              (builtins.split tokenRe content);
+            names = lib.unique (map (m: builtins.head m) matches);
+          in map (name:
+            let parts = lib.splitString "/" name; in {
+              inherit name;
+              owner = builtins.elemAt parts 0;
+              repo  = builtins.elemAt parts 1;
+              source_file = baseNameOf (toString p);
+              user_plugin = true;
+            }
+          ) names;
+
+        all = lib.concatMap extractFromFile luaFiles;
+        dedup = lib.foldl' (acc: p:
+          if lib.any (q: q.name == p.name) acc then acc else acc ++ [p]
+        ) [] all;
+      in lib.sort (a: b: a.name < b.name) dedup;
 
   # Helper function to scan config files from a directory
   scanConfigFiles = configPath: appName:

--- a/test/unit/default.nix
+++ b/test/unit/default.nix
@@ -76,8 +76,9 @@ let
 # Import additional unit tests
 devPathTests = import ./dev-path.nix { inherit pkgs testLib moduleUnderTest; };
 treesitterTests = import ./treesitter-parsers.nix { inherit pkgs testLib moduleUnderTest; };
+scanUserPluginsTests = import ./scan-user-plugins.nix { inherit pkgs testLib moduleUnderTest; };
 
-in devPathTests // treesitterTests // {
+in devPathTests // treesitterTests // scanUserPluginsTests // {
   # Test plugin name resolution
   test-plugin-name-resolution-automatic = testLib.testNixExpr
     "plugin-name-resolution-automatic"

--- a/test/unit/scan-user-plugins.nix
+++ b/test/unit/scan-user-plugins.nix
@@ -1,0 +1,134 @@
+# Unit tests for the pure-Nix scanUserPlugins implementation
+{ pkgs, testLib, moduleUnderTest }:
+
+let
+  fileScanning = import ../../nix/lib/file-scanning.nix {
+    inherit (pkgs) lib;
+    inherit pkgs;
+    config = {};
+  };
+
+  # Fixture: a config tree containing lua/plugins/ with both a top-level
+  # file and a nested subdirectory; one plugin name appears in both files
+  # to exercise dedup.
+  fixtureWithPlugins = pkgs.runCommand "scan-user-plugins-fixture" {} ''
+    mkdir -p $out/lua/plugins/category
+    cat > $out/lua/plugins/top.lua <<'EOF'
+    return {
+      { "LazyVim/LazyVim" },
+      { "folke/lazy.nvim", dependencies = { "nvim-lua/plenary.nvim" } },
+      { "folke/lazy.nvim" },
+    }
+    EOF
+    cat > $out/lua/plugins/category/nested.lua <<'EOF'
+    return { { "owner/nested-plugin" } }
+    EOF
+  '';
+
+  # Fixture: a directory that exists but has no lua/plugins/ subdirectory.
+  fixtureMissingPluginsDir = pkgs.runCommand "scan-user-plugins-no-plugins" {} ''
+    mkdir -p $out/lua/config
+    echo "-- no plugins here" > $out/lua/config/options.lua
+  '';
+
+in {
+  test-scan-user-plugins-missing-path = testLib.testNixExpr
+    "scan-user-plugins-missing-path"
+    ''
+      let
+        fs = import ${../../nix/lib/file-scanning.nix} {
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+          config = {};
+        };
+      in builtins.length (fs.scanUserPlugins /no/such/path/here)
+    ''
+    "0";
+
+  test-scan-user-plugins-missing-plugins-dir = testLib.testNixExpr
+    "scan-user-plugins-missing-plugins-dir"
+    ''
+      let
+        fs = import ${../../nix/lib/file-scanning.nix} {
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+          config = {};
+        };
+      in builtins.length (fs.scanUserPlugins ${fixtureMissingPluginsDir})
+    ''
+    "0";
+
+  test-scan-user-plugins-extracts-top-level = testLib.testNixExpr
+    "scan-user-plugins-extracts-top-level"
+    ''
+      let
+        fs = import ${../../nix/lib/file-scanning.nix} {
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+          config = {};
+        };
+        names = map (s: s.name) (fs.scanUserPlugins ${fixtureWithPlugins});
+      in builtins.elem "LazyVim/LazyVim" names
+    ''
+    "true";
+
+  test-scan-user-plugins-recurses-subdirectories = testLib.testNixExpr
+    "scan-user-plugins-recurses-subdirectories"
+    ''
+      let
+        fs = import ${../../nix/lib/file-scanning.nix} {
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+          config = {};
+        };
+        names = map (s: s.name) (fs.scanUserPlugins ${fixtureWithPlugins});
+      in builtins.elem "owner/nested-plugin" names
+    ''
+    "true";
+
+  test-scan-user-plugins-dedups = testLib.testNixExpr
+    "scan-user-plugins-dedups"
+    ''
+      let
+        fs = import ${../../nix/lib/file-scanning.nix} {
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+          config = {};
+        };
+        names = map (s: s.name) (fs.scanUserPlugins ${fixtureWithPlugins});
+        lazyCount = builtins.length (builtins.filter (n: n == "folke/lazy.nvim") names);
+      in lazyCount
+    ''
+    "1";
+
+  test-scan-user-plugins-sorted = testLib.testNixExpr
+    "scan-user-plugins-sorted"
+    ''
+      let
+        lib = (import <nixpkgs> {}).lib;
+        fs = import ${../../nix/lib/file-scanning.nix} {
+          inherit lib;
+          pkgs = import <nixpkgs> {};
+          config = {};
+        };
+        names = map (s: s.name) (fs.scanUserPlugins ${fixtureWithPlugins});
+        sorted = lib.sort (a: b: a < b) names;
+      in names == sorted
+    ''
+    "true";
+
+  test-scan-user-plugins-spec-shape = testLib.testNixExpr
+    "scan-user-plugins-spec-shape"
+    ''
+      let
+        fs = import ${../../nix/lib/file-scanning.nix} {
+          lib = (import <nixpkgs> {}).lib;
+          pkgs = import <nixpkgs> {};
+          config = {};
+        };
+        specs = fs.scanUserPlugins ${fixtureWithPlugins};
+        first = builtins.head specs;
+      in first ? name && first ? owner && first ? repo && first ? source_file && first ? user_plugin
+    ''
+    "true";
+}


### PR DESCRIPTION
The lua scanner runs inside a `pkgs.runCommand` consumed by `builtins.readFile`, an IFD that requires a builder for `pkgs.stdenv.system` at module-evaluation time. The constraint is incidental: `scripts/scan-user-plugins.lua` performs no lua-semantic work (`uv.fs_scandir` for filesystem walk, `string.match` for `"owner/repo"` regex extraction, no `dofile`/`loadstring` of plugin specs).

Replace with `lib.filesystem.listFilesRecursive` + `builtins.readFile` + `builtins.split`, mirroring `scanConfigFiles` in the same `nix/lib/file-scanning.nix` file.
