### PR TITLE
fix(deps): Add missing nixpkg mappings for dotnet and tailwind tools

### DIFF
--- a/data/dependencies.json
+++ b/data/dependencies.json
@@ -164,7 +164,8 @@
             "name": "dotnet-sdk",
             "nixpkg": "dotnet-sdk"
           }
-        ]
+        ],
+        "nixpkg": "fsautocomplete"
       },
       {
         "name": "csharpier",
@@ -173,10 +174,12 @@
             "name": "dotnet-sdk",
             "nixpkg": "dotnet-sdk"
           }
-        ]
+        ],
+        "nixpkg": "csharpier"
       },
       {
-        "name": "netcoredbg"
+        "name": "netcoredbg",
+        "nixpkg": "netcoredbg"
       },
       {
         "name": "fantomas",
@@ -185,7 +188,8 @@
             "name": "dotnet-sdk",
             "nixpkg": "dotnet-sdk"
           }
-        ]
+        ],
+        "nixpkg": "fantomas"
       }
     ],
     "lang.elm": [
@@ -446,7 +450,8 @@
     ],
     "lang.tailwind": [
       {
-        "name": "tailwindcss"
+        "name": "tailwindcss",
+        "nixpkg": "tailwindcss"
       }
     ],
     "lang.terraform": [

--- a/nix/lib/dependencies.nix
+++ b/nix/lib/dependencies.nix
@@ -22,6 +22,10 @@
             else if ignoreBuildNotifications then null
             else builtins.trace "Warning: Package '${pkgName}' not found in nixpkgs" null;
 
+        # Package managers that are intentionally not mapped to nixpkgs
+        # (mirrors the exclusion list in scripts/extract-dependencies.lua)
+        knownPackageManagers = [ "pip" "npm" "composer" "luarocks" "opam" "gem" ];
+
         # Helper function to warn about unmapped tools
         warnUnmappedTool = toolName: extraName:
           if ignoreBuildNotifications then null
@@ -74,9 +78,11 @@
                     if tool ? runtime_dependencies then map (dep:
                       if dep ? nixpkg then
                         resolvePackage dep.nixpkg
+                      else if builtins.elem dep.name knownPackageManagers then
+                        null  # Package managers are intentionally unmapped
                       else if ignoreBuildNotifications then null
                       else
-                        builtins.trace "Info: Runtime dependency '${dep.name}' for tool '${tool.name}' in '${extraName}' has no nixpkg mapping (may be a package manager like pip/npm)" null
+                        builtins.trace "Info: Runtime dependency '${dep.name}' for tool '${tool.name}' in '${extraName}' has no nixpkg mapping" null
                     ) tool.runtime_dependencies else []
                   ) extraTools))
                 else [];

--- a/scripts/extract-dependencies.lua
+++ b/scripts/extract-dependencies.lua
@@ -443,6 +443,15 @@ local function resolve_package_name(dep_name)
         -- Debug adapters
         codelldb = "vscode-extensions.vadimcn.vscode-lldb",
 
+        -- .NET tools
+        fsautocomplete = "fsautocomplete",
+        csharpier = "csharpier",
+        netcoredbg = "netcoredbg",
+        fantomas = "fantomas",
+
+        -- CSS tools
+        tailwindcss = "tailwindcss",
+
         -- Runtime packages
         nodejs = "nodejs",
         cargo = "cargo",


### PR DESCRIPTION
## Summary

Adds `nixpkg` mappings for 5 tools that were causing `builtins.trace` "Info" warnings at build time because they had no package resolution path:

- `fsautocomplete` → `pkgs.fsautocomplete` (lang.dotnet)
- `csharpier` → `pkgs.csharpier` (lang.dotnet)
- `netcoredbg` → `pkgs.netcoredbg` (lang.dotnet)
- `fantomas` → `pkgs.fantomas` (lang.dotnet)
- `tailwindcss` → `pkgs.tailwindcss` (lang.tailwind)

Both `data/dependencies.json` and `scripts/extract-dependencies.lua` are updated:
- **JSON**: Build-time input consumed by `nix/lib/dependencies.nix`
- **Lua script**: Source of truth for the `direct_mappings` table used when regenerating dependencies

All 5 packages verified to exist in nixpkgs unstable. `nix flake check` passes.

**Note**: `tailwindcss` in nixpkgs is an alias for `tailwindcss_3` not `tailwindcss_4`

## Silence package manager traces

Also adds a `knownPackageManagers` list to `nix/lib/dependencies.nix` that mirrors the exclusion in `scripts/extract-dependencies.lua`. Package managers (`pip`, `npm`, `composer`, `luarocks`, `opam`, `gem`) are intentionally not mapped to nixpkgs — they are provided by their respective runtime dependencies (e.g. `nodejs` provides `npm`). Previously these emitted `Info` traces during evaluation; now they are silently skipped.

## Testing

```bash
nix flake check  # passes
```