### PR TITLE
Replace defunct magic-nix-cache with cache-nix-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
 
       - name: Run test suite
         run: nix-build test/ -A runAll
+        env:
+          # test/default.nix imports <nixpkgs>; resolve it via the flake registry
+          NIX_PATH: nixpkgs=flake:nixpkgs
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v16
+        uses: nixbuild/nix-quick-install-action@v34
 
       - name: Cache Nix store
-        uses: DeterminateSystems/magic-nix-cache-action@v8
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-test-${{ hashFiles('**/*.nix', 'flake.lock', 'data/**') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-test-
+          gc-max-store-size-linux: 4G
 
       - name: Run test suite
         run: nix-build test/ -A runAll
@@ -29,13 +33,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v16
+        uses: nixbuild/nix-quick-install-action@v34
 
       - name: Cache Nix store
-        uses: DeterminateSystems/magic-nix-cache-action@v8
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-lint-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-lint-
+          gc-max-store-size-linux: 2G
 
       - name: statix
         run: nix run nixpkgs#statix -- check .
@@ -47,13 +55,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v16
+        uses: nixbuild/nix-quick-install-action@v34
 
       - name: Cache Nix store
-        uses: DeterminateSystems/magic-nix-cache-action@v8
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-flake-check-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-flake-check-
+          gc-max-store-size-linux: 2G
 
       - name: nix flake check
         run: nix flake check


### PR DESCRIPTION
Fixes the 18 annotations (3 errors, 15 warnings) on every CI run.

## Problem

`magic-nix-cache-action` is defunct: the free magic-nix-cache service was sunset, so the action fails FlakeHub authentication (the errors) and its fallback to GitHub's legacy cache API returns 400 (the warnings). Net effect: caching silently did nothing and every CI run was a cold build. The remaining warnings were Node 20 deprecation notices for `checkout@v4`/`nix-installer-action@v16`, which GitHub force-migrates to Node 24 on June 16.

## Changes

- Install Nix with `nixbuild/nix-quick-install-action@v34` (single-user install, required for store caching to work)
- Cache the Nix store per job with `nix-community/cache-nix-action@v7` using GitHub's native cache, keyed on nix files / flake.lock / data, with prefix fallback and store GC caps
- Bump `actions/checkout` to v6 (Node 24)

This PR is also the first real test of the auto-merge flow: it should merge itself once the required checks pass.