### PR TITLE
Exclude updater-created PRs from auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,13 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.event.pull_request.user.login == 'pfassina' && !github.event.pull_request.draft
+    # Skip PRs from the updater workflows: they are created with PR_TOKEN and
+    # so carry the token owner's authorship, but should be reviewed manually.
+    if: >-
+      github.event.pull_request.user.login == 'pfassina' &&
+      !github.event.pull_request.draft &&
+      !startsWith(github.head_ref, 'update-lazyvim-plugins') &&
+      !startsWith(github.head_ref, 'fix-parser-hashes')
     runs-on: ubuntu-latest
     steps:
       - name: Enable squash auto-merge


### PR DESCRIPTION
Now that updater workflows create PRs with `PR_TOKEN`, those PRs carry the token owner's authorship and would qualify for auto-merge. Skip the `update-lazyvim-plugins` and `fix-parser-hashes` branches so plugin-update PRs are still reviewed and merged manually.