### PR TITLE
Stop LazyVim runtime treesitter installs under Nix

### DIFF
--- a/nix/lib/dev-path.nix
+++ b/nix/lib/dev-path.nix
@@ -48,10 +48,11 @@ rec {
   # Generate dev plugin specs for available plugins
   generateDevPluginSpecs = self: allPluginSpecs: resolvedPlugins:
     let
+      # nvim-treesitter is excluded here because the starter patcher injects a
+      # dedicated spec for it (see starter-patcher.nix defaultTreesitterSpec).
       devPluginSpecs = lib.zipListsWith (spec: plugin:
         if plugin != null &&
-           spec.name != "nvim-treesitter/nvim-treesitter" &&
-           spec.name != "nvim-treesitter/nvim-treesitter-textobjects" then
+           spec.name != "nvim-treesitter/nvim-treesitter" then
           ''{ "${self.getRepoName spec.name}", dev = true, pin = true },''
         else
           null

--- a/nix/lib/starter-patcher.nix
+++ b/nix/lib/starter-patcher.nix
@@ -30,29 +30,16 @@ let
     fallback = false,
   },'';
 
-  # The treesitter spec for Nix-managed parsers
+  # The treesitter spec for Nix-managed parsers.
+  # Parsers and queries are pre-built by Nix and linked into
+  # stdpath("data")/site, where nvim-treesitter (main branch) discovers them.
+  # LazyVim's own spec provides opts/event/config; only disable the build
+  # step and point lazy.nvim at the Nix-managed plugin.
   defaultTreesitterSpec = ''
 {
       "nvim-treesitter/nvim-treesitter",
-      event = { "BufReadPost", "BufNewFile", "BufWritePre", "VeryLazy" },
-      cmd = { "TSUpdate", "TSInstall", "TSLog", "TSUninstall" },
       -- [NIX] Parser compilation is skipped when using Nix
       build = false,
-      opts = {
-        auto_install = false,
-        ensure_installed = {},
-        highlight = { enable = true },
-        indent = { enable = true },
-        incremental_selection = {
-          enable = true,
-          keymaps = {
-            init_selection = "<C-space>",
-            node_incremental = "<C-space>",
-            scope_incremental = false,
-            node_decremental = "<bs>",
-          },
-        },
-      },
       dev = true,
       pin = true,
     },'';

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -321,21 +321,50 @@ in {
           };
         }
     )
-    # Disable LazyVim's treesitter healthcheck - Nix provides pre-built parsers
+    # Disable LazyVim's runtime treesitter installer - Nix provides pre-built parsers
     // {
-      "${cfg.appName}/lua/plugins/_lazyvim_nix_healthcheck.lua" = {
+      "${cfg.appName}/lua/plugins/_lazyvim_nix_treesitter.lua" = {
         text = ''
-          -- [NIX] Disable treesitter healthcheck - parsers are pre-built by Nix
-          -- LazyVim's healthcheck expects tree-sitter CLI and C compiler which aren't needed
+          -- [NIX] Treesitter parsers are pre-built by Nix and linked into
+          -- stdpath("data")/site. LazyVim's runtime installer needs the
+          -- tree-sitter CLI and a C compiler, and would try to write into the
+          -- read-only parser directory, so replace it with a clear message.
+          --
+          -- LazyDone fires before any LazyFile/VeryLazy plugin loads, so the
+          -- overrides are in place before LazyVim's treesitter config runs.
           vim.api.nvim_create_autocmd("User", {
-            pattern = "VeryLazy",
+            pattern = "LazyDone",
             once = true,
             callback = function()
               local ok, ts = pcall(require, "lazyvim.util.treesitter")
-              if ok and ts then
-                ts.check = function()
-                  return true, { ["nix"] = true }
+              if not ok or not ts then
+                return
+              end
+              -- Healthcheck: parsers come from Nix, so requirements are met
+              ts.check = function()
+                return true, { ["nix"] = true }
+              end
+              -- Called by LazyVim when ensure_installed parsers are missing
+              ts.build = function()
+                local plugin = require("lazy.core.config").plugins["nvim-treesitter"]
+                local opts = plugin and require("lazy.core.plugin").values(plugin, "opts", false) or {}
+                local missing = vim.tbl_filter(function(lang)
+                  return not ts.have(lang)
+                end, opts.ensure_installed or {})
+                if #missing == 0 then
+                  return
                 end
+                vim.notify(
+                  table.concat({
+                    "Treesitter parsers are managed by Nix; runtime installation is disabled.",
+                    "",
+                    "Missing parsers: `" .. table.concat(missing, "`, `") .. "`",
+                    "",
+                    "Add them to `programs.lazyvim.treesitterParsers` or enable the corresponding extra.",
+                  }, "\n"),
+                  vim.log.levels.WARN,
+                  { title = "lazyvim-nix" }
+                )
               end
             end,
           })

--- a/test/unit/dev-path.nix
+++ b/test/unit/dev-path.nix
@@ -44,7 +44,9 @@ let
 
   devPath = createDevPath devPathSpecs devPathResolved;
 
-  # generateDevPluginSpecs must exclude treesitter plugins and unresolved ones
+  # generateDevPluginSpecs must exclude nvim-treesitter (it gets a dedicated
+  # spec from the starter patcher) and unresolved plugins; everything else,
+  # including nvim-treesitter-textobjects, is dev-managed
   devSpecs = generateDevPluginSpecs devPathLib [
     { name = "folke/lazy.nvim"; }
     { name = "nvim-treesitter/nvim-treesitter"; }
@@ -94,10 +96,10 @@ in {
     (builtins.head devSpecs)
     ''{ "lazy.nvim", dev = true, pin = true },'';
 
-  # generateDevPluginSpecs: treesitter plugins and unresolved plugins are
-  # excluded, leaving only the one regular resolved plugin
+  # generateDevPluginSpecs: nvim-treesitter and unresolved plugins are
+  # excluded, leaving lazy.nvim and nvim-treesitter-textobjects
   test-dev-specs-exclusions = testLib.testEval
     "dev-specs-exclusions"
     (builtins.length devSpecs)
-    1;
+    2;
 }


### PR DESCRIPTION
Fixes #95

LazyVim v16 with nvim-treesitter `main` installs missing `ensure_installed` parsers at runtime. That path needs a C compiler and the tree-sitter CLI, and writes into the read-only Nix-managed parser directory — so whenever any requested parser isn't provided by Nix, users get the misleading "Unmet requirements for **nvim-treesitter** `main`" error from the issue.

## Changes

- **Replace the healthcheck override** (`_lazyvim_nix_healthcheck.lua` → `_lazyvim_nix_treesitter.lua`): the old override patched `lazyvim.util.treesitter.check` on `VeryLazy`, which was too late when Neovim opens a file directly (the treesitter plugin loads on `LazyFile` first), and forcing `check()` to pass made LazyVim proceed with the doomed install into the store. The new override hooks `User LazyDone` (fires before any plugin loads) and replaces `LazyVim.treesitter.build` so it never installs at runtime and instead reports which parsers are missing, pointing at `programs.lazyvim.treesitterParsers`/extras.
- **Modernize the injected treesitter spec**: drop master-branch options (`auto_install`, `incremental_selection`, `ensure_installed = {}` — a no-op due to `opts_extend`) that are dead config on the `main` branch; keep `build = false, dev = true, pin = true`.
- **Dev-manage `nvim-treesitter-textobjects`**: the dev-spec exclusion was a master-era leftover, so lazy.nvim cloned it from GitHub at runtime (unpinned `main` HEAD, version skew against the Nix-pinned nvim-treesitter, network dependency on first start). It is already in the dev path, so mark it `dev`/`pin` like the rest.

## Verification

- Full test suite: 138/138 passing; statix and deadnix clean.
- Headless end-to-end runs of the generated config against nixpkgs 26.x (Neovim 0.12, nvim-treesitter `main` packaging):
  - Fresh default setup: all core parsers detected by `nvim-treesitter`, highlighting active, no notifications, no runtime clones — for both `pluginSource = "latest"` and `"nixpkgs"`.
  - Missing-parser scenario (user spec requesting `zig`/`rust`): actionable `lazyvim-nix` warning naming the parsers, no install attempt, instead of the compiler/CLI requirements error.
  - Race case (`nvim &lt;file&gt;`, where `LazyFile` fires before `VeryLazy`): the override is in place before LazyVim's treesitter config runs.
- Activated on a real NixOS system (nixos-unstable) and confirmed: no startup errors, textobjects served from the Nix dev path.

Note for the reporter: a fresh default deployment on nixpkgs 26.x verifies healthy end-to-end, so the original report likely involves a parser requested by an extra/user spec that Nix didn't provide. With this change that situation produces an explicit message naming the parsers instead of the misleading requirements error — if parsers are still missing after updating, the message will say which ones.