### PR TITLE
Add flake lib output with Lua generation helpers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,9 @@
       homeManagerModules.default = ./nix/module.nix;
       homeManagerModules.lazyvim = ./nix/module.nix;
 
+      # Helpers for writing programs.lazyvim.plugins values as Nix attrsets
+      lib = import ./nix/lib/lua-generation.nix { inherit (nixpkgs) lib; };
+
       overlays.default = final: _prev: {
         lazyvimPluginData = builtins.fromJSON (builtins.readFile ./data/plugins.json);
         lazyvimPluginMappings = builtins.fromJSON (builtins.readFile ./data/mappings.json);

--- a/nix/lib/lua-generation.nix
+++ b/nix/lib/lua-generation.nix
@@ -1,0 +1,47 @@
+# Public Lua-generation helpers, exposed via the flake's top-level `lib`
+# output (issue #73). They generate lazy.nvim plugin spec Lua code from Nix
+# attrsets, so `programs.lazyvim.plugins` values can be written as Nix
+# instead of raw Lua strings. Embed Lua code (e.g. functions) inside a spec
+# with lib.generators.mkLuaInline.
+#
+# Not related to the internal `lazyConfig` in config-generation.nix, which
+# patches the lazy.nvim bootstrap config and is not flake-exported.
+{ lib }:
+
+rec {
+  # Render a single lazy.nvim plugin spec table from an attrset.
+  # The `plugin` attr becomes the table's bare positional string
+  # ({ "owner/repo", ... }), which toLua cannot express on its own (it has no
+  # syntax for mixed positional/keyed tables). `indent` only controls
+  # formatting and is not part of the spec.
+  lazyPlugin =
+    spec@{ indent ? "", ... }:
+    let
+      attrs = removeAttrs spec [ "plugin" "indent" ];
+      lua = lib.generators.toLua { inherit indent; } attrs;
+    in
+    if !(spec ? plugin) then
+      lua
+    else if attrs == { } then
+      "{ ${builtins.toJSON spec.plugin} }"
+    else
+      # toJSON escapes the plugin name the same way toLua escapes every other
+      # string. substring with negative length means "to the end", so this
+      # splices the plugin name in as the table's first entry.
+      "{\n${indent}  ${builtins.toJSON spec.plugin}," + builtins.substring 1 (-1) lua;
+
+  # Generate a complete plugin file body ("return ...") from a single spec
+  # attrset or a list of spec attrsets, suitable as a
+  # `programs.lazyvim.plugins.<name>` value.
+  lazyConfig =
+    specs:
+    "return "
+    + (
+      if builtins.isAttrs specs then
+        lazyPlugin specs
+      else
+        lib.generators.toLua { } (
+          map (spec: lib.generators.mkLuaInline (lazyPlugin (spec // { indent = "  "; }))) specs
+        )
+    );
+}

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -347,11 +347,29 @@ with lib;
             end,
           }
         ''';
+
+        # Generated from Nix attrsets via the flake's lib helpers
+        tokyonight-from-nix = inputs.lazyvim-nix.lib.lazyConfig {
+          plugin = "folke/tokyonight.nvim";
+          opts = { style = "night"; transparent = true; };
+        };
+
+        # Embed Lua code (e.g. functions) with lib.generators.mkLuaInline
+        noice-from-nix = inputs.lazyvim-nix.lib.lazyConfig {
+          plugin = "folke/noice.nvim";
+          opts.routes = lib.generators.mkLuaInline "function() return my_routes end";
+        };
       }
     '';
     description = ''
       Plugin configuration files. Each key becomes a file lua/plugins/{key}.lua
       with the corresponding Lua code. These files are automatically loaded by LazyVim.
+
+      Values are raw Lua. To generate them from Nix attrsets instead, use the
+      flake's helpers: `inputs.lazyvim-nix.lib.lazyConfig` (single spec or list
+      of specs) and `inputs.lazyvim-nix.lib.lazyPlugin` (single spec table).
+      Use `lib.generators.mkLuaInline` from nixpkgs to embed Lua code, such as
+      functions, inside a spec attrset.
     '';
   };
 }

--- a/test/unit/lua-generation.nix
+++ b/test/unit/lua-generation.nix
@@ -1,0 +1,146 @@
+# Unit tests for the public Lua-generation helpers (the flake's `lib` output).
+# These import and call the real implementation in nix/lib/lua-generation.nix.
+{ pkgs, testLib, ... }:
+
+let
+  inherit (pkgs) lib;
+
+  # The real library under test, imported exactly as flake.nix does
+  luaGen = import ../../nix/lib/lua-generation.nix { inherit lib; };
+  inherit (luaGen) lazyPlugin lazyConfig;
+in
+{
+  test-lua-gen-single-spec-with-plugin = testLib.testEval
+    "lua-gen-single-spec-with-plugin"
+    (lazyConfig {
+      plugin = "folke/tokyonight.nvim";
+      opts = { style = "night"; transparent = true; };
+    })
+    ''
+      return {
+        "folke/tokyonight.nvim",
+        ["opts"] = {
+          ["style"] = "night",
+          ["transparent"] = true
+        }
+      }'';
+
+  # A spec with only `plugin` must not glue the closing brace to the comma
+  test-lua-gen-plugin-only = testLib.testEval
+    "lua-gen-plugin-only"
+    (lazyConfig { plugin = "folke/noice.nvim"; })
+    ''return { "folke/noice.nvim" }'';
+
+  # Without `plugin`, the spec is a plain keyed table (e.g. local dir plugins)
+  test-lua-gen-spec-without-plugin = testLib.testEval
+    "lua-gen-spec-without-plugin"
+    (lazyConfig { dir = "/some/path"; name = "local-plugin"; })
+    ''
+      return {
+        ["dir"] = "/some/path",
+        ["name"] = "local-plugin"
+      }'';
+
+  test-lua-gen-list-of-specs = testLib.testEval
+    "lua-gen-list-of-specs"
+    (lazyConfig [
+      { plugin = "Lazyvim/Lazyvim"; opts.colorscheme = "catppuccin"; }
+      { plugin = "neovim/nvim-lspconfig"; opts.servers.nixd = { }; }
+    ])
+    ''
+      return {
+        ({
+          "Lazyvim/Lazyvim",
+          ["opts"] = {
+            ["colorscheme"] = "catppuccin"
+          }
+        }),
+        ({
+          "neovim/nvim-lspconfig",
+          ["opts"] = {
+            ["servers"] = {
+              ["nixd"] = {}
+            }
+          }
+        })
+      }'';
+
+  test-lua-gen-nested-opts = testLib.testEval
+    "lua-gen-nested-opts"
+    (lazyConfig {
+      plugin = "neovim/nvim-lspconfig";
+      opts = { servers = [ 1 2 ]; enabled = false; count = 3; };
+    })
+    ''
+      return {
+        "neovim/nvim-lspconfig",
+        ["opts"] = {
+          ["count"] = 3,
+          ["enabled"] = false,
+          ["servers"] = {
+            1,
+            2
+          }
+        }
+      }'';
+
+  # mkLuaInline values are emitted as raw Lua, not quoted strings
+  test-lua-gen-mkluainline-passthrough = testLib.testEval
+    "lua-gen-mkluainline-passthrough"
+    (lazyConfig {
+      plugin = "folke/noice.nvim";
+      opts = lib.generators.mkLuaInline "function(_, opts) opts.x = 1 end";
+    })
+    ''
+      return {
+        "folke/noice.nvim",
+        ["opts"] = (function(_, opts) opts.x = 1 end)
+      }'';
+
+  test-lua-gen-empty-attrset = testLib.testEval
+    "lua-gen-empty-attrset"
+    (lazyConfig { })
+    "return {}";
+
+  test-lua-gen-empty-list = testLib.testEval
+    "lua-gen-empty-list"
+    (lazyConfig [ ])
+    "return {}";
+
+  # The plugin name is escaped like every other string
+  test-lua-gen-escapes-plugin-name = testLib.testEval
+    "lua-gen-escapes-plugin-name"
+    (lazyConfig {
+      plugin = "weird\"name\\test";
+      lazy = false;
+    })
+    ''
+      return {
+        "weird\"name\\test",
+        ["lazy"] = false
+      }'';
+
+  test-lua-gen-escapes-string-values = testLib.testEval
+    "lua-gen-escapes-string-values"
+    (lazyConfig {
+      plugin = "a/b";
+      opts.desc = "has \"quotes\" and \\backslash";
+    })
+    ''
+      return {
+        "a/b",
+        ["opts"] = {
+          ["desc"] = "has \"quotes\" and \\backslash"
+        }
+      }'';
+
+  # lazyPlugin renders a bare spec table without the `return` prefix
+  test-lua-gen-lazyplugin-bare = testLib.testEval
+    "lua-gen-lazyplugin-bare"
+    (lazyPlugin { plugin = "a/b"; lazy = false; })
+    ''
+      {
+        "a/b",
+        ["lazy"] = false
+      }'';
+}


### PR DESCRIPTION
Closes #73

Exposes `lazyPlugin` and `lazyConfig` from the flake's top-level `lib` output, as proposed by @dacid44 in #73. They generate lazy.nvim plugin spec Lua code from Nix attrsets, so `programs.lazyvim.plugins` and extras `config` values can be written as structured Nix instead of raw Lua strings:

```nix
programs.lazyvim.plugins.tokyonight = inputs.lazyvim-nix.lib.lazyConfig {
  plugin = "folke/tokyonight.nvim";
  opts = { style = "night"; transparent = true; };
};
```

Lua code (e.g. functions) can still be embedded inside a spec via `lib.generators.mkLuaInline` from nixpkgs, which is documented in the option docstring rather than re-exported.

Two fixes over the code as proposed in the issue:
- a spec containing only `plugin` renders as `{ "name" }` instead of gluing the closing brace to the trailing comma
- the plugin name is escaped with `toJSON`, like every other string in the spec

## Changes
- `nix/lib/lua-generation.nix` (new): the two helpers
- `flake.nix`: top-level `lib` output (system-independent, per the discussion in #73)
- `test/unit/lua-generation.nix` (new): 11 unit tests that import and call the real implementation
- `nix/options.nix`: usage example and docs in the `plugins` option

## Testing
- `nix-build test/ -A runAll`: 149/149 tests pass
- `nix flake check`: passes
- Generated output verified to parse as valid Lua (`lua -e 'assert(loadfile(...))'`), including escaped plugin names and inline functions
- Tested end-to-end in a real NixOS/home-manager config via an extras `config` override (`nixos-rebuild switch` with this branch as the input)