### PR TITLE
fix: nixpkgs strategy ignores available nix packages for wildcard versions

### DIFF
--- a/nix/lib/plugin-resolution.nix
+++ b/nix/lib/plugin-resolution.nix
@@ -124,6 +124,8 @@ let
       # Priority: respect LazyVim's exact specifications first
       targetVersion = if lazyvimVersion != null && lazyvimVersion != "*" && lazyvimVersion != false then
         lazyvimVersion
+      else if lazyvimVersion == "*" && cfg.pluginSource == "nixpkgs" then
+        lazyvimVersion
       else if tagVersion != null then
         tagVersion
       else if latestVersion != null then

--- a/nix/lib/plugin-resolution.nix
+++ b/nix/lib/plugin-resolution.nix
@@ -122,10 +122,9 @@ let
 
       # Determine target version based on LazyVim specifications
       # Priority: respect LazyVim's exact specifications first
-      targetVersion = if lazyvimVersion != null && lazyvimVersion != "*" && lazyvimVersion != false then
-        lazyvimVersion
-      else if lazyvimVersion == "*" && cfg.pluginSource == "nixpkgs" then
-        lazyvimVersion
+      targetVersion = if (lazyvimVersion != null && lazyvimVersion != "*" && lazyvimVersion != false)
+          || (lazyvimVersion == "*" && cfg.pluginSource == "nixpkgs")
+        then lazyvimVersion
       else if tagVersion != null then
         tagVersion
       else if latestVersion != null then

--- a/test/unit/plugin-resolution.nix
+++ b/test/unit/plugin-resolution.nix
@@ -84,6 +84,19 @@ in {
     }).pname
     pkgs.vimPlugins.lazy-nvim.pname;
 
+  # nixpkgs strategy + unpinned "*" should use the nixpkgs package, not source-build the tag
+  test-resolve-plugin-nixpkgs-wildcard-uses-nixpkgs = testLib.testEval
+    "resolve-plugin-nixpkgs-wildcard-uses-nixpkgs"
+    (resolvePlugin { pluginSource = "nixpkgs"; } {
+      name = "folke/lazy.nvim";
+      version_info = {
+        lazyvim_version = "*";
+        tag = "v99.99.99";  # mocks extract-plugins.lua's latest upstream release, not a pin
+        sha256 = lib.fakeSha256;
+      };
+    }).version
+    pkgs.vimPlugins.lazy-nvim.version;
+
   test-resolve-plugin-unresolvable-returns-null = testLib.testEval
     "resolve-plugin-unresolvable-returns-null"
     (resolvePlugin { pluginSource = "nixpkgs"; } {


### PR DESCRIPTION
This is an update to #77, rebased onto current HEAD with test added. Original text below.

----

The first if block makes "*" lead to tag/latest/commit rather than set * for the next if block. This is fine for `pluginSource = "latest"`, but if you want nixpkgs then many plugins are via tag. In the case of blink-cmp at the moment, this leads to commit hash which doesn't match the nix package name.

https://github.com/pfassina/lazyvim-nix/blob/c1c27d9b3fd74d243a34985c5440a14aa0c2a169/nix/lib/plugin-resolution.nix#L126-L145

Hence, I have added a quick extra check for the pluginSource in this check to allow through '*' for the target version.