### PR TITLE
Provide Svelte TypeScript plugin without Mason

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ programs.lazyvim = {
 
 **⚠️ Experimental:** Automatic dependency installation is experimental and might not cover all required packages. Use `extraPackages` for missing dependencies.
 
+### Svelte TypeScript Plugin
+
+Enabling `extras.lang.svelte` automatically installs the matching
+`typescript-svelte-plugin` from nixpkgs and configures LazyVim's package path
+resolver to use its Nix store path. Mason remains disabled; no additional
+configuration is required.
+
 ### Custom Configuration
 
 #### Option 1: Inline Configuration

--- a/nix/lib/package-paths.nix
+++ b/nix/lib/package-paths.nix
@@ -1,0 +1,31 @@
+# Package path resolution for LazyVim extras under Nix
+{ lib }: {
+  configFiles =
+    {
+      appName,
+      enabledExtraNames,
+      typescriptSveltePlugin,
+    }:
+    lib.optionalAttrs (lib.elem "lang.svelte" enabledExtraNames) {
+      "${appName}/lua/plugins/_lazyvim_nix_package_paths.lua" = {
+        text = ''
+          -- [NIX] Resolve packages provided by Nix instead of Mason.
+          local package_paths = {
+            ["svelte-language-server/node_modules/typescript-svelte-plugin"] =
+              "${typescriptSveltePlugin}/lib/node_modules/typescript-svelte-plugin",
+          }
+
+          return {
+            {
+              "LazyVim/LazyVim",
+              opts = {
+                package_path = function(pkg, path)
+                  return package_paths[pkg .. path]
+                end,
+              },
+            },
+          }
+        '';
+      };
+    };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -30,6 +30,7 @@ let
   };
   configLib = import ./lib/config-generation.nix { inherit lib; };
   fileLib = import ./lib/file-scanning.nix { inherit lib; };
+  packagePathsLib = import ./lib/package-paths.nix { inherit lib; };
 
   # Helper function to collect enabled extras
   getEnabledExtras = extrasConfig:
@@ -206,6 +207,12 @@ let
   # Detect conflicts and ensure no conflicts exist
   conflictChecks = fileLib.detectConflicts cfg scannedFiles;
 
+  packagePathConfigFiles = packagePathsLib.configFiles {
+    inherit (cfg) appName;
+    inherit enabledExtraNames;
+    typescriptSveltePlugin = pkgs.typescript-svelte-plugin;
+  };
+
 in {
   # Import module options
   options.programs.lazyvim = import ./options.nix { inherit lib dataLib; };
@@ -306,6 +313,8 @@ in {
     ) scannedFiles.pluginFiles)
     # Generate extras config override files
     // extrasConfigFiles
+    # Resolve extra package paths from Nix store paths
+    // packagePathConfigFiles
     # Add default plugin file when no plugins are defined to prevent LazyVim error
     // (
       let

--- a/test/unit/package-paths.nix
+++ b/test/unit/package-paths.nix
@@ -1,0 +1,43 @@
+{
+  pkgs,
+  testLib,
+  ...
+}:
+let
+  packagePathsLib = import ../../nix/lib/package-paths.nix { inherit (pkgs) lib; };
+  typescriptSveltePlugin = "/nix/store/typescript-svelte-plugin";
+  target = "lazyvim/lua/plugins/_lazyvim_nix_package_paths.lua";
+
+  enabledConfigFiles = packagePathsLib.configFiles {
+    appName = "lazyvim";
+    enabledExtraNames = [ "lang.svelte" ];
+    inherit typescriptSveltePlugin;
+  };
+
+  disabledConfigFiles = packagePathsLib.configFiles {
+    appName = "lazyvim";
+    enabledExtraNames = [ ];
+    inherit typescriptSveltePlugin;
+  };
+
+  config = enabledConfigFiles.${target}.text;
+in
+{
+  test-package-path-config-enabled = testLib.testEval "package-path-config-enabled" (
+    enabledConfigFiles ? ${target}
+  ) true;
+
+  test-package-path-config-uses-lazyvim-resolver =
+    testLib.testEval "package-path-config-uses-lazyvim-resolver"
+      (pkgs.lib.hasInfix "package_path = function(pkg, path)" config)
+      true;
+
+  test-package-path-config-source = testLib.testEval "package-path-config-source" (
+    pkgs.lib.hasInfix ''["svelte-language-server/node_modules/typescript-svelte-plugin"] ='' config
+    && pkgs.lib.hasInfix ''"/nix/store/typescript-svelte-plugin/lib/node_modules/typescript-svelte-plugin"'' config
+  ) true;
+
+  test-package-path-config-disabled = testLib.testEval "package-path-config-disabled" (
+    disabledConfigFiles == { }
+  ) true;
+}


### PR DESCRIPTION
## Problem

lazyvim-nix disables Mason, but LazyVim’s Svelte extra resolves `typescript-svelte-plugin` from Mason’s package directory.

Enabling:

```nix
programs.lazyvim = {
  enable = true;
  extras.lang.svelte.enable = true;
};
```

produces:

```text
Mason package path not found for svelte-language-server:
- /node_modules/typescript-svelte-plugin
You may need to force update the package.
```

Consequently, `vtsls` cannot load the Svelte TypeScript plugin.

Additionally, lazyvim-nix’s dependency extraction confuses the Svelte LSP with the identically named Treesitter parser. Therefore, `extras.lang.svelte.installDependencies = true` does not install `svelte-language-server`.

## Solution

This PR connects two upstream changes:

- [NixOS/nixpkgs#552834](https://github.com/NixOS/nixpkgs/pull/552834) packages `typescript-svelte-plugin`
- [LazyVim/LazyVim#7236](https://github.com/LazyVim/LazyVim/pull/7236) allows external package path resolution

When the Svelte extra is enabled, lazyvim-nix now:

- resolves `typescript-svelte-plugin` from its Nix store path
- keeps Mason disabled
- maps the Svelte LSP to nixpkgs’s `svelte-language-server`
- installs the language server when `installDependencies = true`

No manual package-path configuration or Mason-compatible directory is required.

This PR remains a draft until both upstream dependencies are merged.

## Testing

- `nix-build test/ -A runAll --no-out-link`
- generated Lua checked with `luac -p`
- dependency extraction and package resolution regression tests
- Home Manager evaluation using both prerequisite branches